### PR TITLE
Responsive pagination tray

### DIFF
--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -35,6 +35,8 @@ const icons = {
   firstPage: <path d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"/>,
   lastPage: <path d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"/>,
   // media
+  ellipsis: <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>,
+  // misc
   pause: <Fragment>
           <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/>
           <path d="M0 0h24v24H0z" fill="none"/>

--- a/src/components/search/search-context.js
+++ b/src/components/search/search-context.js
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useRef, useState } from 'r
 import axios from 'axios'
 import { useNavigate } from '@reach/router'
 import { useAuth, useEnvironment } from '../../contexts'
+import { useWindowWidth } from '../../hooks'
 
 //
 
@@ -14,9 +15,13 @@ const PER_PAGE = 10
 
 //
 
-
+const PAGINATION_RADIUS = {
+  mobile: 1,
+  desktop: 3,
+}
 
 export const HelxSearch = ({ children }) => {
+  const { isCompact } = useWindowWidth()
   const { helxSearchUrl } = useEnvironment()
   const [query, setQuery] = useState('')
   const [isLoadingResults, setIsLoadingResults] = useState(false);
@@ -26,9 +31,15 @@ export const HelxSearch = ({ children }) => {
   const [totalResults, setTotalResults] = useState(0)
   const [currentPage, setCurrentPage] = useState(1)
   const [pageCount, setPageCount] = useState(0)
+  const [paginationRadius, setPaginationRadius] = useState(PAGINATION_RADIUS.mobile)
+
   const auth = useAuth()
   const inputRef = useRef()
   const navigate = useNavigate()
+
+  useEffect(() => {
+    setPaginationRadius(isCompact ? PAGINATION_RADIUS.mobile : PAGINATION_RADIUS.desktop)
+  }, [isCompact])
 
   useEffect(() => {
     // this lets the user press backslash to jump focus to the search box
@@ -153,7 +164,14 @@ export const HelxSearch = ({ children }) => {
   }
 
   return (
-    <HelxSearchContext.Provider value={{ query, setQuery, error, isLoadingResults, results, doSelect, resultsSelected, launchApp, totalResults, currentPage, setCurrentPage, perPage: PER_PAGE, pageCount, doSearch, inputRef }}>
+    <HelxSearchContext.Provider value={{
+      query, setQuery, doSearch, inputRef,
+      error, isLoadingResults,
+      results, totalResults,
+      doSelect, resultsSelected,
+      launchApp,
+      currentPage, setCurrentPage, perPage: PER_PAGE, pageCount, paginationRadius,
+    }}>
       { children}
     </HelxSearchContext.Provider>
   )

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export * from './use-registry'
 export * from './use-scroll-position'
+export * from './use-window-width'

--- a/src/hooks/use-window-width.js
+++ b/src/hooks/use-window-width.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+
+let defaultWidth
+
+// This conditional makes the build work.
+// The browser handles this fine during development.
+// However, Node has no window object, so we check here to see if it exists.
+if (typeof window !== 'undefined') {
+    defaultWidth = window.innerWidth
+}
+
+const COMPACT_THRESHOLD = 768
+
+export const useWindowWidth = (initialWidth = defaultWidth) => {
+    const [width, setWidth] = useState(initialWidth)
+    const [isCompact, setIsCompact] = useState(null)
+    
+    useEffect(() => {
+        const determineCompactness = () => width < COMPACT_THRESHOLD
+        setIsCompact(determineCompactness())
+    }, [width])
+
+    useEffect(() => {
+        setWidth(typeof window !== 'undefined' ? window.innerWidth : 0)
+    }, [])
+    
+    useEffect(() => {
+        const handleResize = () => setWidth(window.innerWidth)
+        window.addEventListener('resize', handleResize)
+        return () => {
+            window.removeEventListener('resize', handleResize)
+        }
+    }, [])
+    
+    return { width, isCompact }
+}


### PR DESCRIPTION
Many results yields many pagination links. This condenses the pagination tray to only show a fixed number of links at once. There's a new variable provided by the search context to configure as needed. It's an object with a `desktop` and `mobile` radius for large and smaller screens, respectively.

The pagination tray relies on pagination radius to determine how many links to show on either side of the current page in the pagination tray component.

To illustrate:

```
page 1: [      (1), 2, 3, 4, 5, 6, 7, ... ]
page 2: [      1, (2), 3, 4, 5, 6, 7, ... ]
page 3: [      1, 2, (3), 4, 5, 6, 7, ... ]
page 4: [      1, 2, 3, (4), 5, 6, 7, ... ]
page 5: [ ..., 2, 3, 4, (5), 6, 7, 8, ... ]
page 6: [ ..., 3, 4, 5, (6), 7, 8, 9, ... ]
```

I also added a use-window-width hook to determine which radius to use that will be helpful for other components down the road.