### PR TITLE
Feature/search study

### DIFF
--- a/src/components/external-link.js
+++ b/src/components/external-link.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+export const ExternalLink = styled.a.attrs(props => ({ target: '_blank', rel: 'noopener noreferrer', href: props.to }))``
+
+ExternalLink.propTypes = {
+    to: PropTypes.string.isRequired,
+}

--- a/src/components/search/search-context.js
+++ b/src/components/search/search-context.js
@@ -115,6 +115,21 @@ export const HelxSearch = ({ children }) => {
     return knowledgeGraphs.map(graph => graph._source.knowledge_graph.knowledge_graph)
   }
 
+  const fetchStudyVariable = async (_id, _query) => {
+    const studyVariables = await axios.post(`${helxSearchUrl}/search_var`, {
+      concept: _id,
+      index: 'variables_index',
+      query: _query,
+      size: 1000
+    }).then(response => {
+      return response.data.result.hits.hits
+    }).catch(error => {
+      console.error(error)
+      return []
+    })
+    return studyVariables.map(studyVar => studyVar._source);
+  }
+
   const doSearch = queryString => {
     const trimmedQuery = queryString.trim()
     if (trimmedQuery !== '') {
@@ -151,7 +166,7 @@ export const HelxSearch = ({ children }) => {
 
   return (
     <HelxSearchContext.Provider value={{
-      query, setQuery, doSearch, fetchKnowledgeGraphs, inputRef,
+      query, setQuery, doSearch, fetchKnowledgeGraphs, fetchStudyVariable, inputRef,
       error, isLoadingResults,
       results, totalResults,
       selectedView, setSelectedView, doSelect, resultsSelected, clearSelect,

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useHelxSearch } from './search-context';
+import { useEnvironment } from '../../contexts';
 import styled, { css } from 'styled-components'
 import ReactJson from 'react-json-view'
 import { Icon } from '../icon'
@@ -10,7 +11,9 @@ import { useNotifications } from '../notifications'
 import { Paragraph } from '../typography';
 import { KnowledgeGraphs } from './knowledge-graph';
 import { Collapser } from '../collapser';
-import { useEnvironment } from '../../contexts';
+import { dbGapLink } from '../../utils/dbgap-links';
+import { ExternalLink } from '../external-link';
+import { VariablesList } from './study-variables-list';
 
 const Wrapper = styled.article(({ theme, selected }) => css`
   margin: 1rem 0;
@@ -80,6 +83,9 @@ const CollapserHeader = styled.div`
     padding: 0.5rem 1rem;
 `
 
+const StudyName = styled.div``
+const StudyAccession = styled.div``
+
 const ResultSelector = styled(Button).attrs({ shadow: false })(({ theme, selected }) => `
   position: absolute;
   top: 0;
@@ -95,15 +101,50 @@ const ResultBodyText = styled.p`
 `
 
 export const Result = ({ index, result }) => {
-  const { fetchKnowledgeGraphs, resultsSelected, selectedView, setSelectedView, doSelect } = useHelxSearch();
+  const { query, fetchKnowledgeGraphs, fetchStudyVariable, resultsSelected, selectedView, setSelectedView, doSelect } = useHelxSearch();
   const { addNotification } = useNotifications()
   const [knowledgeGraphs, setKnowledgeGraphs] = useState([]);
+  const [studyVariables, setStudyVariables] = useState([]);
   useEffect(() => {
     const getKgs = async () => {
       const kgs = await fetchKnowledgeGraphs(result.id);
       setKnowledgeGraphs(kgs);
     }
+    const getVar = async () => {
+      const vars = await fetchStudyVariable(result.id, query);
+      const groupedIds = vars.reduce((acc, obj) => {
+        let key = obj["collection_id"];
+        if(!acc[key]){
+          acc[key] = [];
+        }
+        acc[key].push({
+          id: obj.element_id,
+          name: obj.element_name,
+          description: obj.element_desc,
+          e_link: obj.element_action
+        })
+        return acc;
+      }, {})
+      let tem_result = [];
+      vars.reduce((acc, curr) => {
+        const isFind = acc.find(item => item.collection_id === curr.collection_id);
+        if(!isFind){
+          let studyObj = {
+            collection_id: curr.collection_id,
+            collection_action: curr.collection_action,
+            collection_name: curr.collection_name,
+            variables: groupedIds[curr.collection_id]
+          }
+          tem_result.push(studyObj);
+          acc.push(curr);
+        }
+        return acc;
+      }, [])
+      console.log(tem_result)
+      setStudyVariables(tem_result);
+    }
     getKgs();
+    getVar();
   }, [])
   const handleSelectResult = result => event => {
     const notificationText = resultsSelected.has(result.id) ? `Unselected "${result.name}" (${result.id})` : `Selected "${result.name}" (${result.id})`
@@ -113,7 +154,6 @@ export const Result = ({ index, result }) => {
 
   return (
     <Wrapper selected={resultsSelected.has(result.id)}>
-      {/* <div className="index">{index}</div> */}
       <div className="details">
         <div className="result-json">
           <Card>
@@ -126,6 +166,25 @@ export const Result = ({ index, result }) => {
             <Icon icon={resultsSelected.has(result.id) ? 'check' : 'add'} fill="#eee" />
           </ResultSelector> */}
           </Card>
+          {studyVariables.map(({ collection_id, collection_name, collection_link, variables }) => (
+              <Collapser key={`${result.name} ${collection_id}`} ariaId={'studies'} {...collapserStyles}
+                title={
+                  <CollapserHeader>
+                    <StudyName>
+                      <strong>Study</strong>:
+                                    <ExternalLink to={collection_link} >{collection_name}</ExternalLink>
+                    </StudyName>
+                    <StudyAccession>
+                      <strong>Accession</strong>:
+                                    <ExternalLink to={collection_link} >{collection_id.replace(/^TOPMED\.STUDY:/, '')}</ExternalLink>
+                    </StudyAccession>
+                  </CollapserHeader>
+                }
+              >
+                <VariablesList studyId={collection_id.replace(/^TOPMED\.STUDY:/, '')} variables={variables} />
+              </Collapser>
+            ))
+          }
           {knowledgeGraphs.length > 0 && (
             <Collapser key={`${result.name} kg`} ariaId={`${result.name} kg`} {...collapserStyles} title={<CollapserHeader>Knowledge Graph</CollapserHeader>}>
               <KnowledgeGraphs graphs={knowledgeGraphs} />

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -140,7 +140,6 @@ export const Result = ({ index, result }) => {
         }
         return acc;
       }, [])
-      console.log(tem_result)
       setStudyVariables(tem_result);
     }
     getKgs();

--- a/src/components/search/search-results.js
+++ b/src/components/search/search-results.js
@@ -171,19 +171,16 @@ export const SearchResults = () => {
               )
             }
             {
+              results.length === 0 && (
+                <div>No results found!</div>
+              )
+            }
+            {
               currentResults.map((result, i) => {
                 const index = (currentPage - 1) * perPage + i + 1
                 return <Result key={ `result-${ index }` } index={ index } result={ result } />
               })
             }
-            {/* {
-              results.length >= 1 && (
-                <Meta overline>
-                  <div>Results { (currentPage - 1) * perPage + 1 } to { (currentPage - 1) * perPage + results.length } of { totalResults } total results</div>
-                  <div>{ MemoizedActions }</div>
-                </Meta>
-              )
-            } */}
           </Fragment>
         )
       }

--- a/src/components/search/study-variables-list.js
+++ b/src/components/search/study-variables-list.js
@@ -12,7 +12,6 @@ const Wrapper = styled.div`
 
 const VariableLink = styled.a.attrs(props => ({ target: '_blank', rel: 'noopener noreferrer', href: props.to }))`
     display: block;
-    padding: 0.5rem 0;
 `
 
 const List = styled.ul`
@@ -28,8 +27,8 @@ export const VariablesList = ({ studyId, variables }) => {
             <List>
                 {
                     variables.map(variable => (
-                        <ListItem key={ variable }>
-                            <VariableLink to={ dbGapLink.variable(studyId, variable) || null }>{ variable }</VariableLink>
+                        <ListItem key={ variable.id }>
+                            <VariableLink to={variable.e_link}>{variable.id}: {variable.id}</VariableLink>
                         </ListItem>
                     ))
                 }

--- a/src/utils/dbgap-links.js
+++ b/src/utils/dbgap-links.js
@@ -1,0 +1,17 @@
+const DB_GAP_VARIABLE_URL = `https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi`
+const DB_GAP_STUDY_URL = `https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi`
+
+export const dbGapLink = {
+  variable: (studyId, variable) => {
+      // variable always has the form "phv987654321.v12.p23"
+      // and the "987654321" portion is used in the dbGap link
+      const matches = variable.match(/phv(\d+)\.v\d+\.p\d+$/)
+      if (matches) {
+          const [, variableDigits] = matches
+          return variableDigits ? `${ DB_GAP_VARIABLE_URL }?study_id=${ studyId }&phv=${ variableDigits }` : `${ DB_GAP_VARIABLE_URL }?studyId=${ studyId }&phv=${ variable }`
+      } else {
+          return null
+      }
+  },
+  study: studyId => `${ DB_GAP_STUDY_URL }?study_id=${ studyId }`,
+}


### PR DESCRIPTION
This pr features:
- display study variables between search results and knowledge graph (same as dug search)
- display no results when receiving empty response
- clean up log info

I tried to dig into the last week's rendering issue on search page where query is updated but results aren't. I haven't encountered that issue so far, but will look into that once occur.