### PR TITLE
CI Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,4 @@ all: clean install.npm lint test build
 reinstall: clean install.npm build.npm
 
 #ci: orchestrates the steps to be ran for continous integration
-ci: clean install.ci lint test build
+ci: clean install.ci lint test build.image


### PR DESCRIPTION
- Update CI command. Local npm build fails due to docker in docker/jenkins setup on kubernetes. Can't replicate with local docker. Image build succeeds and also runs npm build.