### PR TITLE
Feature/instance readable metrix

### DIFF
--- a/src/components/app/app-card.js
+++ b/src/components/app/app-card.js
@@ -8,7 +8,7 @@ import { Slider } from '../slider';
 import { Paragraph } from '../typography'
 import { LoadingSpinner } from '../spinner/loading-spinner';
 import { useApp } from '../../contexts/app-context';
-import { useEnvironment } from '../../contexts';
+import { toBytes, bytesToMegabytes, formatBytes, formatMemory } from '../../utils/memory-converter';
 import { useNotifications } from '@mwatson/react-notifications'
 
 const AppHeader = styled.div(({ theme }) => `
@@ -107,45 +107,6 @@ const SliderMinMaxContainer = styled.span(({ theme }) => `
   flex-grow: 1;
 `)
 
-const bytePower = (unit_type) => {
-  let ut = unit_type.toLowerCase()
-  const power = {
-    'k': 3,
-    'm': 6,
-    'g': 9,
-    't': 12,
-    'p': 15,
-    'e': 18,
-    'z': 21,
-    'y': 24,
-  }
-
-  return power[ut];
-}
-
-const toBytes = (config) => {
-  let units = config.substring(0, config.length - 1);
-  let power_value = bytePower(config[config.length - 1])
-  return units * Math.pow(10, power_value);
-}
-
-// convert bytes to human readable unit type
-const formatBytes = (bytes, decimals) => {
-  const k = 1000;
-  const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
-
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  const parsed = parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i];
-  return parsed;
-}
-
-const formatMemory = (mb, decimals = 2) => {
-  let bytes = toBytes(mb);
-  return formatBytes(bytes, decimals);
-}
-
-
 // each app config value from localstorage will be validated here
 const validateLocalstorageValue = (config, app_id, min, max) => {
   let prev = localStorage.getItem(`${app_id}-${config}`);
@@ -172,7 +133,7 @@ export const AppCard = ({ name, app_id, description, detail, docs, status, minim
   //app can be launched here using axios to hit the /start endpoint
   const appLauncher = async () => {
     setLaunching(true);
-    await launchApp(app_id, currentCpu, currentGpu, formatBytes(currentMemory))
+    await launchApp(app_id, currentCpu, currentGpu, bytesToMegabytes(currentMemory))
       .then(res => {
         addNotification({ type: 'success', text: 'Launching app successful.' })
       }).catch(e => {

--- a/src/components/app/app-card.js
+++ b/src/components/app/app-card.js
@@ -133,6 +133,7 @@ export const AppCard = ({ name, app_id, description, detail, docs, status, minim
   //app can be launched here using axios to hit the /start endpoint
   const appLauncher = async () => {
     setLaunching(true);
+    // NOTE: Memory is converted to MB when posting an instance
     await launchApp(app_id, currentCpu, currentGpu, bytesToMegabytes(currentMemory))
       .then(res => {
         addNotification({ type: 'success', text: 'Launching app successful.' })

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,3 @@
 export * from './dbgap-links';
 export * from './kg-links';
+export * from './memory-converter';

--- a/src/utils/memory-converter.js
+++ b/src/utils/memory-converter.js
@@ -1,0 +1,41 @@
+const bytePower = (unit_type) => {
+    let ut = unit_type.toLowerCase()
+    const power = {
+        'k': 3,
+        'm': 6,
+        'g': 9,
+        't': 12,
+        'p': 15,
+        'e': 18,
+        'z': 21,
+        'y': 24,
+    }
+
+    return power[ut];
+}
+
+export const toBytes = (config) => {
+    let units = config.substring(0, config.length - 1);
+    let power_value = bytePower(config[config.length - 1])
+    return units * Math.pow(10, power_value);
+}
+
+export const bytesToMegabytes = (bytes) => {
+    return 1000 ^ 2 * bytes;
+}
+
+// convert bytes to human readable unit type
+export const formatBytes = (bytes, decimals) => {
+    const k = 1000;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const parsed = parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i];
+    return parsed;
+}
+
+export const formatMemory = (mb, decimals = 2) => {
+    let bytes = toBytes(mb);
+    return formatBytes(bytes, decimals);
+}

--- a/src/views/active.js
+++ b/src/views/active.js
@@ -107,6 +107,7 @@ export const Active = () => {
         },
         {
             name: 'Memory',
+            // Note: Memory in the response does not contain unit, but it matches the one when we post them (MB by default).
             selector: (row) => { return formatMemory(row.memory + 'M') },
             sortable: true
         }, {

--- a/src/views/active.js
+++ b/src/views/active.js
@@ -8,6 +8,7 @@ import { useInstance } from '../contexts/instance-context';
 import DataTable from 'react-data-table-component';
 import { WorkSpaceTabGroup } from '../components/workspace/workspace-tab-group';
 import { useNotifications } from '@mwatson/react-notifications';
+import { formatMemory } from '../utils/memory-converter';
 
 const StopButton = styled(Button)(({ theme }) => `
     background-color: #ff0000;
@@ -67,7 +68,8 @@ export const Active = () => {
         {
             name: 'App Name',
             selector: 'name',
-            sortable: true
+            sortable: true,
+            grow: 2
         },
         {
             key: "action",
@@ -90,21 +92,22 @@ export const Active = () => {
         {
             name: 'Creation Time',
             selector: 'creation_time',
-            sortable: true
+            sortable: true,
+            grow: 2
         },
         {
             name: 'CPU',
-            selector: 'cpus',
+            selector: (row) => { return row.cpus / 1000 },
             sortable: true
         },
         {
             name: 'GPU',
-            selector: 'gpus',
+            selector: (row) => { return row.gpus / 1000 },
             sortable: true
         },
         {
             name: 'Memory',
-            selector: 'memory',
+            selector: (row) => { return formatMemory(row.memory + 'M') },
             sortable: true
         }, {
             key: "action",

--- a/src/views/active.js
+++ b/src/views/active.js
@@ -97,12 +97,12 @@ export const Active = () => {
         },
         {
             name: 'CPU',
-            selector: (row) => { return row.cpus / 1000 },
+            selector: (row) => { return row.cpus / 1000 + ' Core' + (row.cpus / 1000 > '1' ? 's' : '') },
             sortable: true
         },
         {
             name: 'GPU',
-            selector: (row) => { return row.gpus / 1000 },
+            selector: (row) => { return row.gpus / 1000 + ' Core' + (row.gpus / 1000 > '1' ? 's' : '') },
             sortable: true
         },
         {


### PR DESCRIPTION
This pr:
- modify tableview on active page, so app name / creation time column can grow if needed
- format cpu/gpu listing, add conditional rendering
- post instance will carry memory in megabytes by default, so we can expect the same unit type when getting response from /instance, and then frontend will format it to the appropriate one when rendering.

