### PR TITLE
refactor branding image layout

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -33,7 +33,7 @@ const Brand = styled(Link)(({ theme }) => `
   justify-content: center;
   align-items: center;
   text-decoration: none;
-  padding: ${theme.spacing.medium};
+  padding: ${theme.spacing.xs};
   color: ${theme.color.primary.dark};
   & > img {
     margin: 0;
@@ -85,7 +85,7 @@ const BrandText = styled.div`
 `
 
 const BrandImage = styled.img`
-  max-height: 100px;
+  max-height: 70px;
   object-fit: scale-down;
 `
 

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -85,7 +85,7 @@ const BrandText = styled.div`
 `
 
 const BrandImage = styled.img`
-  width: 10vw;
+  max-height: 100px;
   object-fit: scale-down;
 `
 


### PR DESCRIPTION
Limit the max height of a branding image. Large Image will be scale down, so the menu items won't be stretched.