### PR TITLE
prevent study name from overlapping variable count in search result card

### DIFF
--- a/src/components/search/result-card.css
+++ b/src/components/search/result-card.css
@@ -1,0 +1,4 @@
+.studies-list-item {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/search/result-card.js
+++ b/src/components/search/result-card.js
@@ -9,6 +9,7 @@ import {
   ExperimentOutlined as LaunchIcon,
 } from '@ant-design/icons'
 import { KnowledgeGraphs } from './'
+import './result-card.css'
 
 const { Meta } = Card
 const { Text } = Typography
@@ -45,9 +46,14 @@ export const SearchResultCard = ({ index, result, openModalHandler }) => {
                 <List.Item>
                   <List.Item.Meta
                     title={ <span>Study: <Link to={variable.collection_action}>{variable.collection_name}</Link></span> }
-                    description={<span>Accession: <Link to={variable.collection_action}>{variable.collection_id.replace(/^TOPMED\.STUDY:/, '')}</Link></span>}
+                    description={
+                      <div className="studies-list-item">
+                        <Text>Accession: <Link to={variable.collection_action}>{variable.collection_id.replace(/^TOPMED\.STUDY:/, '')}</Link></Text>
+                        <Text>{ variable.variables.length } variable{ variable.variables.length === 1 ? '' : 's' }</Text>
+                      </div>
+                    }
                   />
-                  <Text>{ variable.variables.length } variable{ variable.variables.length === 1 ? '' : 's' }</Text>
+                  
                 </List.Item>
                 <br/>
               </Fragment>

--- a/src/components/search/result-card.js
+++ b/src/components/search/result-card.js
@@ -45,9 +45,10 @@ export const SearchResultCard = ({ index, result, openModalHandler }) => {
               <Fragment>
                 <List.Item>
                   <List.Item.Meta
-                    title={ <span>Study: <Link to={variable.collection_action}>{variable.collection_name}</Link></span> }
+                    className="studies-list-item"
+                    title={ <span className="studies-list-item__title">Study: <Link to={variable.collection_action}>{variable.collection_name}</Link></span> }
                     description={
-                      <div className="studies-list-item">
+                      <div className="studies-list-item__description">
                         <Text>Accession: <Link to={variable.collection_action}>{variable.collection_id.replace(/^TOPMED\.STUDY:/, '')}</Link></Text>
                         <Text>{ variable.variables.length } variable{ variable.variables.length === 1 ? '' : 's' }</Text>
                       </div>


### PR DESCRIPTION
this fixes the rendering collision illustrated in the image below

![image (1)](https://user-images.githubusercontent.com/6019870/120835209-0356f800-c532-11eb-949a-f6e726fb8588.png)
