### PR TITLE
Bugfix/pre search loading spinner

### DIFF
--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -21,11 +21,9 @@ export const HelxSearch = ({ children }) => {
   const [isLoadingResults, setIsLoadingResults] = useState(false);
   const [error, setError] = useState({})
   const [results, setResults] = useState([])
-  const [resultsSelected, setResultsSelected] = useState(new Map());
   const [totalResults, setTotalResults] = useState(0)
   const [currentPage, setCurrentPage] = useState(1)
   const [pageCount, setPageCount] = useState(0)
-  const [selectedView, setSelectedView] = useState(false);
   const location = useLocation()
 
   const inputRef = useRef()
@@ -53,12 +51,9 @@ export const HelxSearch = ({ children }) => {
   }, [location.search])
 
   useEffect(() => {
-    // close selected view when loading new search
-    setSelectedView(false);
     const fetchResults = async () => {
       setIsLoadingResults(true)
       try {
-        // dug api
         const params = {
           index: 'concepts_index',
           query: query,
@@ -74,6 +69,7 @@ export const HelxSearch = ({ children }) => {
         } else {
           setResults([])
           setTotalResults(0)
+          setIsLoadingResults(false)
         }
       } catch (error) {
         console.log(error)
@@ -81,7 +77,9 @@ export const HelxSearch = ({ children }) => {
         setIsLoadingResults(false)
       }
     }
-    fetchResults()
+    if (query) {
+      fetchResults()
+    }
   }, [query, currentPage, helxSearchUrl, setResults, setError])
 
   useEffect(() => {
@@ -132,37 +130,12 @@ export const HelxSearch = ({ children }) => {
     }
   }
 
-  // This function will handle all checked items and store them in a state array,
-  // along with update and remove each items. Each checkbox action will invoke this function
-  const doSelect = newSelect => {
-    let newSet = new Map(resultsSelected);
-    if (!newSet.has(newSelect.id)) {
-      newSet.set(newSelect.id, newSelect);
-    }
-    else {
-      newSet.delete(newSelect.id)
-    }
-    setResultsSelected(newSet);
-  }
-
-  // clear all selected history
-
-  const clearSelect = () => {
-    setResultsSelected(new Map());
-    setSelectedView(false);
-  }
-
-  const launchApp = () => {
-    console.log(resultsSelected);
-  }
 
   return (
     <HelxSearchContext.Provider value={{
       query, setQuery, doSearch, fetchKnowledgeGraphs, fetchStudyVariables, inputRef,
       error, isLoadingResults,
       results, totalResults,
-      selectedView, setSelectedView, doSelect, resultsSelected, clearSelect,
-      launchApp,
       currentPage, setCurrentPage, perPage: PER_PAGE, pageCount,
     }}>
       { children}

--- a/src/components/search/form.js
+++ b/src/components/search/form.js
@@ -26,6 +26,7 @@ export const SearchForm = () => {
     <Form onFinish={ () => doSearch(searchTerm) } className="search-form">
       <Form.Item>
         <Input
+          allowClear
           autoFocus
           ref={inputRef}
           placeholder="Enter search term"

--- a/src/components/search/results.js
+++ b/src/components/search/results.js
@@ -33,20 +33,20 @@ export const SearchResults = () => {
     </div>
   ), [currentPage, pageCount, totalResults, query])
 
+  if (isLoadingResults) {
+    return <Spin />
+  }
+
   return (
     <Fragment>
 
-      { isLoadingResults && <Spin /> }
-
-      { !isLoadingResults && error && <span>{ error.message }</span> }
+      { error && <span>{ error.message }</span> }
 
       {
-        query && !isLoadingResults && !error.message && (
+        query && !error.message && (
           <div className="results">
             { results.length >= 1 && MemoizedResultsHeader }
 
-            { results.length === 0 && <div>Your search <b>{query}</b> did not match any documents.</div> }
-            
             <div className="grid">
               {
                 results.map((result, i) => {

--- a/src/components/search/results.js
+++ b/src/components/search/results.js
@@ -48,7 +48,6 @@ export const SearchResults = () => {
             { results.length === 0 && <div>Your search <b>{query}</b> did not match any documents.</div> }
             
             <div className="grid">
-              {console.log(results)}
               {
                 results.map((result, i) => {
                   const index = (currentPage - 1) * perPage + i + 1


### PR DESCRIPTION
this PR
- solves the rendering of the loading indicator before search
- removes the results selection logic (bc it isn't used)
- adds a clear button to the search input

@connectbo i'd appreciate a second set of eyes on this solution to the first bullet above.