### PR TITLE
Enhancement/search interface tweaks

### DIFF
--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -138,7 +138,7 @@ export const HelxSearch = ({ children }) => {
       results, totalResults,
       currentPage, setCurrentPage, perPage: PER_PAGE, pageCount,
     }}>
-      { children}
+      { children }
     </HelxSearchContext.Provider>
   )
 }

--- a/src/components/search/form.css
+++ b/src/components/search/form.css
@@ -1,6 +1,20 @@
 .search-form {
   display: flex;
   gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: 1080px;
+  margin: auto !important;
+  transition:  min-height 500ms ease-out;
+}
+
+.search-form.with-results {
+  min-height: 0;
+}
+
+.search-form.without-results {
+  min-height: 20rem;
 }
 
 .ant-form-item:first-child {

--- a/src/components/search/form.js
+++ b/src/components/search/form.js
@@ -4,7 +4,7 @@ import { useHelxSearch } from './'
 import './form.css'
 
 export const SearchForm = () => {
-  const { query, doSearch, inputRef } = useHelxSearch()
+  const { doSearch, inputRef, query, totalResults } = useHelxSearch()
   const [searchTerm, setSearchTerm] = useState(query)
 
   const handleChangeQuery = event => setSearchTerm(event.target.value)
@@ -23,7 +23,7 @@ export const SearchForm = () => {
   useEffect(() => setSearchTerm(query), [query])
 
   return (
-    <Form onFinish={ () => doSearch(searchTerm) } className="search-form">
+    <Form onFinish={ () => doSearch(searchTerm) } className={ `search-form ${ totalResults ? 'with-results' : 'without-results' }` }>
       <Form.Item>
         <Input
           allowClear

--- a/src/components/search/results.js
+++ b/src/components/search/results.js
@@ -68,7 +68,7 @@ export const SearchResults = () => {
 
       <br/><br/>
 
-      <PaginationTray />
+      { pageCount > 1 && <PaginationTray /> }
 
       <SearchResultModal
         result={modalResult}

--- a/src/components/search/results.js
+++ b/src/components/search/results.js
@@ -34,7 +34,7 @@ export const SearchResults = () => {
   ), [currentPage, pageCount, totalResults, query])
 
   if (isLoadingResults) {
-    return <Spin />
+    return <Spin style={{ display: 'block', margin: '4rem' }} />
   }
 
   return (


### PR DESCRIPTION
this improves the search interface in a couple small ways.

- prevent the search input from stretching across a very large screen by setting a max width of 1080px.
- center (vertically) the search input until search results are returned, then animate input to top of page.