### PR TITLE
tweak kg styling & relocate edge reference links

### DIFF
--- a/src/components/search/knowledge-graphs.css
+++ b/src/components/search/knowledge-graphs.css
@@ -2,26 +2,33 @@
   position: relative;
   display: block;
   margin: 0 auto;
-  background-color: crimson;
+  background-color: salmon;
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  border: 2px solid #000;
+  border: 1px solid #333;
   box-sizing: content-box;
   z-index: 2;
 }
 
 .edge {
-  position:               relative;
-  border-bottom: 1px dashed crimson;
   color: #666;
   font-size: 80%;
-  display: block;
-  height: 22px;
-  margin: 0;
+  display: flex;
+  flex-direction: column;
   width: 200%;
   transform: translate(-25%, -15px);
+}
+.edge-type {
+  position: relative;
+  border-bottom: 2px dotted salmon;
+  height: 22px;
+  margin: 0;
   z-index: 1;
+}
+.edge-label {
+}
+.edge-references {
 }
 
 .source-label, .target-label {

--- a/src/components/search/knowledge-graphs.js
+++ b/src/components/search/knowledge-graphs.js
@@ -26,10 +26,9 @@ const KnowledgeGraph = ({ graph }) => {
       <div className="target-label"><Link to={kgLink.get_curie_purl(interaction.target.id)}>{interaction.target.name}</Link></div>
 
       <div className="source-node"><span className="node" /></div>
-      <div className="type-edge">
-        <span className="edge">
-          {interaction.type}
-          &nbsp;
+      <div className="edge">
+        <div className="edge-type">{interaction.type}</div>
+        <div className="edge-references">
           {
             interaction.publications.map((publication, i) => (
               <Fragment key={`${interaction.source}-pub-${i + 1}`}>
@@ -37,7 +36,7 @@ const KnowledgeGraph = ({ graph }) => {
               </Fragment>
             ))
           }
-        </span>
+        </div>
       </div>
       <div className="target-node"><span className="node" /></div>
     </Fragment>


### PR DESCRIPTION
this tweaks the style & layout for knowledge graph rendering. the current KG layout looks cluttered when several reference publications are present, as shown the following screenshot.

![Screenshot from 2021-06-24 10-58-39](https://user-images.githubusercontent.com/6019870/123285810-61e11780-d4db-11eb-8a20-5f745bb214d7.png)

this change will rearrange items slightly to render the reference links under the knowledge graph edge, as shown in the following screenshot.

![Screenshot from 2021-06-24 10-58-57](https://user-images.githubusercontent.com/6019870/123286023-8b9a3e80-d4db-11eb-8f4c-8e70770d25ba.png)

i've also reduced the node border width and softened the node fill color from crimson to salmon.
