### PR TITLE
Feature/disable appstore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.dockerignore
+build
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore

--- a/.env.sample
+++ b/.env.sample
@@ -1,18 +1,11 @@
-REACT_APP_HELX_SEARCH_URL=https://helx.renci.org
-REACT_APP_ENABLE_SEMANTIC_SEARCH=true
-REACT_APP_ENABLE_WORKSPACES=true
-BUILD_PATH=./build/frontend
-SECRET_KEY=
-DEV_PHASE=stub
-DEBUG=true
-DJANGO_SETTINGS=heal
-ALLOW_DJANGO_LOGIN=true
-EMAIL_HOST_USER=
-EMAIL_HOST_PASSWORD=
-WHITELIST_REDIRECT=false
-OAUTH_PROVIDERS=github
-GITHUB_NAME=local-github
-GITHUB_CLIENT_ID=<insert-id>
-GITHUB_SECRET=<insert-secret>
-AUTHORIZED_USERS=<user>@renci.org,<github-email>
-NAMESPACE=default
+NODE_ENV=development
+REACT_APP_HELX_APPSTORE_ENABLED='false'
+
+# Settings if NODE_ENV=development
+REACT_APP_HELX_SEARCH_URL='https://heal-dev.blackbalsam-cluster.edc.renci.org'
+REACT_APP_SEMANTIC_SEARCH_ENABLED='true'
+REACT_APP_WORKSPACES_ENABLED='false'
+
+# Brand setting if HeLx Appstore is disabled <braini, catalyst, heal, scidas, eduhelx>
+REACT_APP_UI_BRAND_NAME='catalyst'
+REACT_APP_UI_BRAND_LOGO='https://raw.githubusercontent.com/helxplatform/appstore/b2cb2bf88c5fbca95534611737fdf78c5afb7bac/appstore/core/static/images/catalyst/bdc-logo.svg'

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IDE files
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,17 @@
-###################
-# Build environment
-###################
-FROM node:14.16.1-alpine AS builder
-RUN apk add make
-# Create and set working directory
-RUN mkdir /src
-WORKDIR /src
-# Copy in source files
-COPY . /src
-# Build app
-RUN make clean install.npm lint test build.npm
+FROM node:14.16.1-alpine AS build
 
-########################
-# Production environment
-########################
-FROM nginx:latest
-COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=builder /src/build/ /usr/share/nginx/static/
-RUN mv /usr/share/nginx/static/frontend/index.html /usr/share/nginx/html/
+# Copy and install requirements
+WORKDIR /usr/src/app
+COPY "package*.json" /usr/src/app/
+RUN npm ci --only=production
 
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+############
+
+FROM node:14.16.1-alpine
+ENV NODE_ENV production
+USER node
+WORKDIR /usr/src/app
+COPY --chown=node:node --from=build /usr/src/app/node_modules /usr/src/app/node_modules
+COPY --chown=node:node . /usr/src/app
+
+CMD npm run start

--- a/docker-compose.helxui.yml
+++ b/docker-compose.helxui.yml
@@ -10,4 +10,4 @@ services:
     env_file:
       .env
     ports:
-      - 2000:80
+      - 3000:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "helx-ui",
-  "version": "0.1.0",
+  "version": "2.0.0-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8906,11 +8906,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
-    "lodash.orderby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.orderby/-/lodash.orderby-4.6.0.tgz",
-      "integrity": "sha1-5pfwTOXXhSL1TZM4syuBozk+TrM="
-    },
     "lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
@@ -13141,21 +13136,6 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "optional": true
-    },
-    "shortid": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-      "requires": {
-        "nanoid": "^2.1.0"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "2.1.11",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
-        }
-      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helx-ui",
-  "version": "1.1.1-dev.0",
+  "version": "2.0.0-dev.0",
   "private": true,
   "homepage": "/static/frontend",
   "dependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -22,9 +22,10 @@ const ContextProviders = ({ children }) => {
 
 const Router = () => {
   const { routes } = useEnvironment();
+  const baseRouterPath = process.env.REACT_APP_HELX_APPSTORE_ENABLED === 'true' ? '/helx' : '/'
   
   return (
-    <ReachRouter basepath="/helx">
+    <ReachRouter basepath={baseRouterPath}>
       {routes !== undefined && routes.map(({ path, text, Component }) => <Component path={path}>{console.log(Component)}</Component>)}
       <NotFoundView default />
     </ReachRouter>

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -9,16 +9,20 @@ import './layout.css';
 const { Header, Content, Footer } = AntLayout
 
 export const Layout = ({ children }) => {
-  const { helxAppstoreUrl, routes, context } = useEnvironment()
+  const { helxAppstoreUrl, routes, context, basePath} = useEnvironment()
+  const baseLinkPath = process.env.REACT_APP_HELX_APPSTORE_ENABLED === 'true' ? '/helx' : ''
   const location = useLocation();
 
   return (
     <AntLayout className="layout">
       <Header style={{ display: 'flex', zIndex: 1, width: '100%', background: '#fff' }}>
-        {context !== undefined ? <Link to="/helx"><img className="brand_img" src={'' + helxAppstoreUrl + context.logo_url} alt="Go Home"></img></Link> : <span />}
+        {context !== undefined ? <Link to={basePath}><img className="brand_img" src={'' + context.logo_url} alt={context.brand}></img></Link> : <span />}
         <Menu className="menu-toggle" style={{ position: 'absolute', right: '2px' }} theme="light" mode="horizontal" selectedKeys={[location.pathname]}>
-          {routes.map(m => m['text'] !== '' && <Menu.Item key={`/helx${m.path}`}><Link to={`/helx${m.path}`}>{m.text}</Link></Menu.Item>)}
-          <Button type="primary" ghost className="logout-button" onClick={() => logoutHandler(helxAppstoreUrl)}>LOG OUT</Button>
+          <Menu.Item style={{ visibility: 'hidden' }}></Menu.Item>
+          <Menu.Item style={{ visibility: 'hidden' }}></Menu.Item>
+          <Menu.Item style={{ visibility: 'hidden' }}></Menu.Item>
+          {routes.map(m => m['text'] !== '' && <Menu.Item key={`/helx${m.path}`}><Link to={`${baseLinkPath}${m.path}`}>{m.text}</Link></Menu.Item>)}
+          {process.env.REACT_APP_HELX_APPSTORE_ENABLED === 'true' && <Button type="primary" ghost className="logout-button" onClick={() => logoutHandler(helxAppstoreUrl)}>LOG OUT</Button>}
         </Menu>
         <MobileMenu menu={routes} />
       </Header>

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -9,7 +9,7 @@ import './layout.css';
 const { Header, Content, Footer } = AntLayout
 
 export const Layout = ({ children }) => {
-  const { helxAppstoreUrl, routes, context, basePath} = useEnvironment()
+  const { helxAppstoreUrl, routes, context, basePath } = useEnvironment()
   const baseLinkPath = process.env.REACT_APP_HELX_APPSTORE_ENABLED === 'true' ? '/helx' : ''
   const location = useLocation();
 
@@ -28,7 +28,7 @@ export const Layout = ({ children }) => {
       </Header>
       <Content>
         {children}
-        <SidePanel />
+        {context.env.REACT_APP_WORKSPACES_ENABLED === 'true' && <SidePanel />}
       </Content>
       <Footer style={{ textAlign: 'center' }}>&copy; HeLx {new Date().getFullYear()}</Footer>
     </AntLayout>

--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -29,7 +29,7 @@ const validateResult = result => {
 }
 
 export const HelxSearch = ({ children }) => {
-  const { helxSearchUrl } = useEnvironment()
+  const { helxSearchUrl, basePath } = useEnvironment()
   const [query, setQuery] = useState('')
   const [isLoadingResults, setIsLoadingResults] = useState(false);
   const [error, setError] = useState({})
@@ -156,7 +156,7 @@ export const HelxSearch = ({ children }) => {
     if (trimmedQuery !== '') {
       setQuery(trimmedQuery)
       setCurrentPage(1)
-      navigate(`/helx/search?q=${trimmedQuery}&p=1`)
+      navigate(`${basePath}search?q=${trimmedQuery}&p=1`)
     }
   }
 

--- a/src/components/search/pagination-tray/pagination-tray.js
+++ b/src/components/search/pagination-tray/pagination-tray.js
@@ -1,10 +1,12 @@
 import { navigate } from '@reach/router'
 import { Pagination, Space } from 'antd'
 import { useHelxSearch } from '../'
+import { useEnvironment } from '../../../contexts'
 import './pagination-tray.css'
 
 export const PaginationTray = () => {
   const { query, totalResults, currentPage } = useHelxSearch()
+  const { basePath } = useEnvironment();
 
   return (
     <Space role="navigation" aria-label="Pagination Navigation" className="pagination-tray">
@@ -13,7 +15,7 @@ export const PaginationTray = () => {
         defaultPageSize={20}
         total={ totalResults }
         showTotal={total => `${ total } results`}
-        onChange={ (page, pageSize) => navigate(`/helx/search?q=${ query }&p=${ page }`) }
+        onChange={ (page, pageSize) => navigate(`${basePath}search?q=${ query }&p=${ page }`) }
         showSizeChanger={ false }
       />
     </Space>

--- a/src/components/search/results/results.js
+++ b/src/components/search/results/results.js
@@ -8,6 +8,7 @@ import {
 } from '@ant-design/icons'
 import { PaginationTray, SearchResultCard, SearchResultModal, useHelxSearch } from '../'
 import './results.css'
+import { useEnvironment } from '../../../contexts'
 
 const { Text } = Typography
 
@@ -16,10 +17,11 @@ const LIST = 'LIST'
 
 export const SearchResults = () => {
   const { query, results, totalResults, perPage, currentPage, pageCount, isLoadingResults, error, setSelectedResult } = useHelxSearch()
+  const { basePath } = useEnvironment()
   const [layout, setLayout] = useState(GRID)
 
   const NotifyLinkCopied = () => {
-    notification.open({ key: 'key', message: 'Link copied to clipboard'})
+    notification.open({ key: 'key', message: 'Link copied to clipboard' })
     navigator.clipboard.writeText(window.location.href)
   }
 
@@ -27,14 +29,14 @@ export const SearchResults = () => {
 
   const MemoizedResultsHeader = useMemo(() => (
     <div className="header">
-      <Text>{ totalResults } results for "{ query }" ({ pageCount } page{ pageCount > 1 && 's' })</Text> 
+      <Text>{totalResults} results for "{query}" ({pageCount} page{pageCount > 1 && 's'})</Text>
       <Tooltip title="Shareable link" placement="top">
-        <Link to={ `/helx/search?q=${ query }&p=${ currentPage }` } onClick={NotifyLinkCopied}><LinkIcon /></Link>
+        <Link to={`${basePath}search?q=${query}&p=${currentPage}`} onClick={NotifyLinkCopied}><LinkIcon /></Link>
       </Tooltip>
       <Tooltip title="Toggle Layout" placement="top">
-        <Radio.Group value={ layout } onChange={ handleChangeLayout }>
-          <Radio.Button value={ GRID }><GridViewIcon /></Radio.Button>
-          <Radio.Button value={ LIST }><ListViewIcon /></Radio.Button>
+        <Radio.Group value={layout} onChange={handleChangeLayout}>
+          <Radio.Button value={GRID}><GridViewIcon /></Radio.Button>
+          <Radio.Button value={LIST}><ListViewIcon /></Radio.Button>
         </Radio.Group>
       </Tooltip>
     </div>

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -25,12 +25,11 @@ axios.interceptors.response.use(function (response) {
 export const EnvironmentContext = createContext({})
 
 let devContext = {
-  "brand": "heal",
+  "brand": process.env.REACT_APP_UI_BRAND_NAME || 'heal',
   "title": "NIH HEAL Initiative",
-  "logo_url": "/static/images/heal/logo.png",
+  "logo_url": process.env.REACT_APP_UI_BRAND_LOGO || 'https://github.com/helxplatform/appstore/blob/master/appstore/core/static/images/heal/logo.png?raw=true',
   "color_scheme": { "primary": "#8a5a91", "secondary": "#505057" },
   "links": null,
-  "capabilities": ["app", "search"],
   "env": {
     "REACT_APP_HELX_SEARCH_URL": process.env.REACT_APP_HELX_SEARCH_URL || 'https://helx.renci.org',
     "REACT_APP_SEMANTIC_SEARCH_ENABLED": process.env.REACT_APP_SEMANTIC_SEARCH_ENABLED || 'true',
@@ -43,6 +42,7 @@ export const EnvironmentProvider = ({ children }) => {
   const [availableRoutes, setAvailableRoutes] = useState([]);
   const [context, setContext] = useState({});
   const [isLoadingContext, setIsLoadingContext] = useState(true);
+  const [basePath, setBasePath] = useState(process.env.REACT_APP_HELX_APPSTORE_ENABLED === 'true' ? '/helx/' : '/');
 
   const generateRoutes = (searchEnabled, workspaceEnabled) => {
     console.log("generate Routes")
@@ -70,21 +70,22 @@ export const EnvironmentProvider = ({ children }) => {
   }
 
   const loadContext = async () => {
-    const context_response = await axios({
+    let context_response = await axios({
       method: 'GET',
       url: `${relativeHost}/api/v1/context`
     })
+    context_response.data.logo_url = window.location.origin + context_response.data.logo_url
     setContext(context_response.data);
     setIsLoadingContext(false);
   }
 
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' || process.env.REACT_APP_HELX_APPSTORE_ENABLED === 'false') {
       setContext(devContext);
       setIsLoadingContext(false);
     }
     else {
-     loadContext();
+      loadContext();
     }
   }, [relativeHost])
 
@@ -103,6 +104,7 @@ export const EnvironmentProvider = ({ children }) => {
       helxAppstoreUrl: window.location.origin,
       context: context,
       routes: availableRoutes,
+      basePath,
       isLoadingContext
     }}>
       {children}

--- a/src/views/search.js
+++ b/src/views/search.js
@@ -2,10 +2,12 @@ import { Fragment } from 'react'
 import { HelxSearch, SearchForm, SearchResults } from '../components/search'
 import { Typography } from 'antd'
 import { Breadcrumbs } from '../components/layout'
+import { useEnvironment } from '../contexts'
 
 const { Title } = Typography
 
 export const SearchView = () => {
+  const { context } = useEnvironment();
 
   const breadcrumbs = [
     { text: 'Home', path: '/helx' },
@@ -14,11 +16,11 @@ export const SearchView = () => {
 
   return (
     <Fragment>
-      
-      <Breadcrumbs crumbs={ breadcrumbs } />
 
-      <Title level={ 1 }>Search</Title>
-      
+      {context.env.REACT_APP_WORKSPACES_ENABLED === 'true' && <Breadcrumbs crumbs={breadcrumbs} />}
+
+      {context.env.REACT_APP_WORKSPACES_ENABLED === 'true' && <Title level={1}>Search</Title>}
+
       <HelxSearch>
         <SearchForm />
         <SearchResults />


### PR DESCRIPTION
This pr 
- allows ui deployment without appstore authentication
- update .env.sample, you can specify the search url, brand info (name and logo), along with the option to enable/disable modules
- change basepath from '/helx' to '/' when appstore is disabled
- fixed the menu bug when it shows three dots instead of text on initial render
*New Update:
- hide the side drawer when workspace module is disabled per Steve request.