### PR TITLE
show study variables in result modal

### DIFF
--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -84,7 +84,6 @@ export const HelxSearch = ({ children }) => {
           size: PER_PAGE,
         }
         const response = await axios.post(`${helxSearchUrl}/search`, params)
-        console.log(response)
         if (response.status === 200 && response.data.status === 'success' && response?.data?.result?.hits) {
           const unsortedHits = response.data.result.hits.hits.map(r => r._source)
           // gather invalid results: remove from rendered results and dump to console.

--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -84,6 +84,7 @@ export const HelxSearch = ({ children }) => {
           size: PER_PAGE,
         }
         const response = await axios.post(`${helxSearchUrl}/search`, params)
+        console.log(response)
         if (response.status === 200 && response.data.status === 'success' && response?.data?.result?.hits) {
           const unsortedHits = response.data.result.hits.hits.map(r => r._source)
           // gather invalid results: remove from rendered results and dump to console.

--- a/src/components/search/result-modal/result-modal.css
+++ b/src/components/search/result-modal/result-modal.css
@@ -1,8 +1,17 @@
 .modal-content-container {
   padding: 1rem;
+  width: 100% !important;
   max-height: 600px;
   overflow-y:  auto;
   scrollbar-width: thin; /* firefox only */
   scrollbar-color: #00000022 transparent; /* firefox only */
   transition: scrollbar-color 250ms; /* firefox only */
+}
+
+.ant-space {
+  width: 100%;
+}
+
+.ant-modal-body > .ant-space > .ant-space-item:nth-child(2) {
+  width: 100% !important;
 }

--- a/src/components/search/result-modal/result-modal.css
+++ b/src/components/search/result-modal/result-modal.css
@@ -15,3 +15,22 @@
 .ant-modal-body > .ant-space > .ant-space-item:nth-child(2) {
   width: 100% !important;
 }
+
+.study-variables-list {
+  font-size: 90% !important;
+}
+
+.study-variables-list-item {
+  margin-left: 0.4rem !important;
+  padding-left: 1rem !important;
+  border-left:  2px solid #eee;
+  margin-bottom: 0.5rem;
+}
+
+.variable-name {
+  font-weight: 500;
+}
+
+.variable-description {
+  font-style: italic;
+}

--- a/src/components/search/result-modal/result-modal.js
+++ b/src/components/search/result-modal/result-modal.js
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react'
-import { List, Menu, Modal, Space, Tag, Typography } from 'antd'
+import { Fragment, useEffect, useState } from 'react'
+import { Collapse, List, Menu, Modal, Space, Tag, Typography } from 'antd'
 import './result-modal.css'
 import { KnowledgeGraphs, useHelxSearch } from '../'
 import { Link } from '../../link'
 
 const { Text, Title } = Typography
 const { CheckableTag: CheckableFacet } = Tag
+const { Panel } = Collapse
 
 const OverviewTab = ({ result }) => {
   return (
@@ -51,26 +52,32 @@ const StudiesTab = ({ studies }) => {
           ))
         }
       </Space>
-      <List
-        className="studies-list"
-        dataSource={
+      <Collapse ghost className="variables-collapse">
+        {
           Object.keys(studies)
             .filter(facet => selectedFacets.includes(facet))
             .reduce((arr, facet) => [...arr, ...studies[facet]], [])
             .sort((s, t) => s.c_name < t.c_name ? -1 : 1)
+            .map(item => (
+              <Panel
+                key={ `panel_${ item.c_name }` }
+                header={
+                    <Text>
+                      { item.c_name }{ ` ` }
+                      (<Link to={ item.c_link }>{ item.c_id }</Link>)
+                    </Text>
+                }
+                extra={ <Text>{ item.elements.length } variable{ item.elements.length === 1 ? '' : 's' }</Text> }
+              >
+                <List
+                  className="variables-list"
+                  dataSource={ item.elements }
+                  renderItem={ variable => <div><Text>{ variable.name }</Text></div> }
+                />
+              </Panel>
+            ))
         }
-        renderItem={ item => (
-          <List.Item>
-            <div className="studies-list-item">
-              <Text className="study-name">
-                { item.c_name }{ ` ` }
-                (<Link to={ item.c_link }>{ item.c_id }</Link>)
-              </Text>
-              <Text className="variables-count">{ item.elements.length } variable{ item.elements.length === 1 ? '' : 's' }</Text>
-            </div>
-          </List.Item>
-        ) }
-      />
+      </Collapse>
    </Space>
   )
 }
@@ -125,7 +132,7 @@ export const SearchResultModal = ({ result, visible, closeHandler }) => {
       onOk={ closeHandler }
       okText="Close"
       onCancel={ closeHandler }
-      width={ 800 }
+      width={ 1200 }
       style={{ top: 135 }}
       bodyStyle={{ padding: `0`, minHeight: `50vh` }}
       cancelButtonProps={{ hidden: true }}

--- a/src/components/search/result-modal/result-modal.js
+++ b/src/components/search/result-modal/result-modal.js
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Collapse, List, Menu, Modal, Space, Tag, Typography } from 'antd'
 import './result-modal.css'
 import { KnowledgeGraphs, useHelxSearch } from '../'
@@ -20,7 +20,6 @@ const OverviewTab = ({ result }) => {
 const StudiesTab = ({ studies }) => {
   const [facets, setFacets] = useState([])
   const [selectedFacets, setSelectedFacets] = useState([])
-  const [loading, setLoading] = useState(true)
 
   const handleSelectFacet = (facet, checked) => {
     const newSelection = new Set(selectedFacets)

--- a/src/components/search/result-modal/result-modal.js
+++ b/src/components/search/result-modal/result-modal.js
@@ -62,17 +62,23 @@ const StudiesTab = ({ studies }) => {
               <Panel
                 key={ `panel_${ item.c_name }` }
                 header={
-                    <Text>
-                      { item.c_name }{ ` ` }
-                      (<Link to={ item.c_link }>{ item.c_id }</Link>)
-                    </Text>
+                  <Text>
+                    { item.c_name }{ ` ` }
+                    (<Link to={ item.c_link }>{ item.c_id }</Link>)
+                  </Text>
                 }
                 extra={ <Text>{ item.elements.length } variable{ item.elements.length === 1 ? '' : 's' }</Text> }
+                onChange={ console.log(item.elements) }
               >
                 <List
-                  className="variables-list"
+                  className="study-variables-list"
                   dataSource={ item.elements }
-                  renderItem={ variable => <div><Text>{ variable.name }</Text></div> }
+                  renderItem={ variable => (
+                    <div className="study-variables-list-item">
+                      <Text className="variable-name"> { variable.name } (<a href={ variable.e_link }>{ variable.id }</a>)</Text><br />
+                      <Text className="variable-description"> { variable.description }</Text>
+                    </div>
+                  ) }
                 />
               </Panel>
             ))

--- a/src/components/search/result-modal/result-modal.js
+++ b/src/components/search/result-modal/result-modal.js
@@ -67,7 +67,6 @@ const StudiesTab = ({ studies }) => {
                   </Text>
                 }
                 extra={ <Text>{ item.elements.length } variable{ item.elements.length === 1 ? '' : 's' }</Text> }
-                onChange={ console.log(item.elements) }
               >
                 <List
                   className="study-variables-list"


### PR DESCRIPTION
merging this PR will change how the studies lists are rendered in the result modal.

a collapsible list of variables for each study associated to the result will be shown. note that this adds this for the modal only, to prevent cluttering up the smaller result cards.