### PR TITLE
hide tab menu item text for smaller screen sizes

### DIFF
--- a/src/components/search/result-modal/result-modal.css
+++ b/src/components/search/result-modal/result-modal.css
@@ -34,3 +34,13 @@
 .variable-description {
   font-style: italic;
 }
+
+.tab-name {
+  display: none;
+}
+
+@media (min-width: 600px) {
+  .tab-name {
+    display: inline;
+  }
+}

--- a/src/components/search/result-modal/result-modal.js
+++ b/src/components/search/result-modal/result-modal.js
@@ -3,6 +3,12 @@ import { Collapse, List, Menu, Modal, Space, Tag, Typography } from 'antd'
 import './result-modal.css'
 import { KnowledgeGraphs, useHelxSearch } from '../'
 import { Link } from '../../link'
+import {
+  InfoCircleOutlined as OverviewIcon,
+  BookOutlined as StudiesIcon,
+  ShareAltOutlined as KnowledgeGraphsIcon,
+  CodeOutlined as TranQLIcon,
+} from '@ant-design/icons'
 
 const { Text, Title } = Typography
 const { CheckableTag: CheckableFacet } = Tag
@@ -124,9 +130,9 @@ export const SearchResultModal = ({ result, visible, closeHandler }) => {
   }
 
   const tabs = {
-    'overview': { title: 'Overview',         content: <OverviewTab result={ result } />, },
-    'studies':  { title: `Studies`,          content: <StudiesTab studies={ studies } />, },
-    'kgs':      { title: `Knowledge Graphs`, content: <KnowledgeGraphsTab graphs={ graphs } />, },
+    'overview': { title: 'Overview',            icon: <OverviewIcon />,         content: <OverviewTab result={ result } />, },
+    'studies':  { title: 'Studies',             icon: <StudiesIcon />,          content: <StudiesTab studies={ studies } />, },
+    'kgs':      { title: 'Knowledge Graphs',    icon: <KnowledgeGraphsIcon />,  content: <KnowledgeGraphsTab graphs={ graphs } />, },
   }
 
   return (
@@ -143,14 +149,17 @@ export const SearchResultModal = ({ result, visible, closeHandler }) => {
     >
       <Space direction="horizontal" align="start">
         <Menu
-          style={{ width: 256, height: '100%' }}
           defaultSelectedKeys={ ['overview'] }
           mode="inline"
           theme="light"
         >
-          <Menu.Item key="overview" onClick={ () => setCurrentTab('overview') }>Overview</Menu.Item>
-          <Menu.Item key="studies" onClick={ () => setCurrentTab('studies') }>Studies</Menu.Item>
-          <Menu.Item key="kgs" onClick={ () => setCurrentTab('kgs') }>Knowledge Graphs</Menu.Item>
+          {
+            Object.keys(tabs).map(key => (
+              <Menu.Item className="tab-menu-item" key={ key } onClick={ () => setCurrentTab(key) }>
+                <span className="tab-icon">{ tabs[key].icon }</span> &nbsp; <span className="tab-name">{ tabs[key].title }</span>
+              </Menu.Item>
+            ))
+          }
         </Menu>
         <div className="modal-content-container" children={ tabs[currentTab].content } />
       </Space>


### PR DESCRIPTION
the result modal doesn't look good on small screens:

![Screenshot from 2021-08-20 10-40-59](https://user-images.githubusercontent.com/6019870/130250698-42ba79c4-c20b-4645-846d-eeeb25c2a09e.png)

this PR (1) adds icons to the modal tabs (overview, studies, kgs):

![Screenshot from 2021-08-20 10-41-26](https://user-images.githubusercontent.com/6019870/130250697-f204c0fa-0056-46e6-83b2-262a6fc07719.png)

and (2) omits the menu items' text labels on smaller screens:

![Screenshot from 2021-08-20 10-41-34](https://user-images.githubusercontent.com/6019870/130250696-c0cddbf3-6dbb-4c83-be62-e83e14edca83.png)
