### PR TITLE
conditionally render study variable links

### DIFF
--- a/src/components/search/result-modal/result-modal.js
+++ b/src/components/search/result-modal/result-modal.js
@@ -73,7 +73,10 @@ const StudiesTab = ({ studies }) => {
                   dataSource={ item.elements }
                   renderItem={ variable => (
                     <div className="study-variables-list-item">
-                      <Text className="variable-name"> { variable.name } (<a href={ variable.e_link }>{ variable.id }</a>)</Text><br />
+                      <Text className="variable-name">
+                        { variable.name } &nbsp;
+                        ({ variable.e_link ? <a href={ variable.e_link }>{ variable.id }</a> : variable.id })
+                      </Text><br />
                       <Text className="variable-description"> { variable.description }</Text>
                     </div>
                   ) }


### PR DESCRIPTION
this PR will change how study variables rendered by rendering a link if possible -- i.e., if `e_link` is present -- or only the variable id otherwise.