### PR TITLE
stop app page reloading after launch

### DIFF
--- a/src/contexts/app-context.js
+++ b/src/contexts/app-context.js
@@ -6,7 +6,6 @@ export const AppContext = createContext({});
 
 export const AppProvider = ({ children }) => {
     const { helxAppstoreUrl } = useEnvironment();
-    const [lastLaunchedTime, setLastLaunchTime] = useState();
 
     const launchApp = (app_id, cpu, gpu, memory) => {
         const params = {
@@ -15,7 +14,6 @@ export const AppProvider = ({ children }) => {
             memory: memory,
             gpus: gpu
         };
-        setLastLaunchTime(new Date())
         return axios.post(`${helxAppstoreUrl}/api/v1/instances/`, params);
     }
 
@@ -26,7 +24,7 @@ export const AppProvider = ({ children }) => {
 
     return (
         <AppContext.Provider value={{
-            launchApp, loadApps, lastLaunchedTime
+            launchApp, loadApps
         }}>
             {children}
         </AppContext.Provider>

--- a/src/views/workspaces/available.js
+++ b/src/views/workspaces/available.js
@@ -12,7 +12,7 @@ export const AvailableView = () => {
     const [apps, setApps] = useState();
     const [runningInstances, setRunningInstances] = useState();
     const [filteredApps, setFilteredApps] = useState();
-    const { lastLaunchedTime, loadApps } = useApp();
+    const { loadApps } = useApp();
     const { loadInstances } = useInstance();
     const [isLoading, setLoading] = useState(false);
     const breadcrumbs = [
@@ -34,7 +34,7 @@ export const AvailableView = () => {
                 })
         }
         renderApp();
-    }, [lastLaunchedTime])
+    }, [])
 
     useEffect(() => {
         const filterApps = async (a) => {


### PR DESCRIPTION
This pr removes the `last launch time` variable and prevent app page from reloading after a successful launch.