### PR TITLE
add argus brand logo and fix issue

### DIFF
--- a/src/components/layout/menu/mobile-menu.js
+++ b/src/components/layout/menu/mobile-menu.js
@@ -3,10 +3,12 @@ import { Button, Drawer, Menu } from 'antd'
 import { MenuOutlined } from '@ant-design/icons'
 import { logoutHandler } from '../../../api/'
 import { Link } from '@reach/router'
+import { useEnvironment } from '../../../contexts/environment-context'
 import '../layout.css'
 
 export const MobileMenu = ({menu}) => {
     const [visible, setVisible] = useState(false);
+    const { helxAppstoreUrl } = useEnvironment();
 
     return (
         <div className="mobile-menu-toggle">
@@ -20,7 +22,7 @@ export const MobileMenu = ({menu}) => {
             >
                 <Menu mode="vertical">
                     {menu.map(m => m['text'] !== '' && <Menu.Item key={m.text}><Link to={`/helx${m.path}`}>{m.text}</Link></Menu.Item>)}
-                    <Menu.Item key="logout" className="logout"><Button onClick={() => logoutHandler()}>LOG OUT</Button></Menu.Item>
+                    <Menu.Item key="logout" className="logout"><Button onClick={() => logoutHandler(helxAppstoreUrl)}>LOG OUT</Button></Menu.Item>
                 </Menu>
             </Drawer>
         </div>

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -83,8 +83,12 @@ export const EnvironmentProvider = ({ children }) => {
       case 'heal':
         context.logo_url = 'https://raw.githubusercontent.com/helxplatform/appstore/master/appstore/core/static/images/heal/logo.png'
         break;
+      case 'argus':
+        context.logo_url = 'https://raw.githubusercontent.com/helxplatform/appstore/master/appstore/core/static/images/argus/argus-array-256.png'
+        break;
+      // display helx logo in case no brand is defined
       default:
-        context.logo_url = ''
+        context.logo_url = 'https://raw.githubusercontent.com/helxplatform/appstore/master/appstore/core/static/images/helx.jpg'
     }
     setContext(context);
     setIsLoadingContext(false);


### PR DESCRIPTION
This pr should let ui
- supported argus branding
- rendered helx logo if no specific brand is defined
- fixed the logout mobile button issue by passing in the appstore url

![image](https://user-images.githubusercontent.com/33065086/136263640-765374a2-3685-49e5-a863-d09fb9ea0f61.png)
