### PR TITLE
Session expire redirect 404 avoidance 

### DIFF
--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -18,7 +18,7 @@ axios.interceptors.response.use(function (response) {
   return response;
 }, function (error) {
   if (error.response.status === 403) {
-    window.location.href = window.location.origin + '/helx/login'
+    window.location.href = window.location.origin + '/helx/login/';
   }
   return Promise.reject(error)
 })


### PR DESCRIPTION
This is to avoid a 404 that arises when a session expiry occurs.  The UI sets window location to `/helx/login`, but technically this URL doesn't exist, it's actually `/helx/login/` which is treated differently, normally the trailing slash is appended for normal page loads automatically, but the exception is the login adaptor, which will redirect to the nonexistent URL on successful login thus 404.

This is perhaps is an approximate fix as the `next=` augment is not completely used to the fullest.