### PR TITLE
Enhancement/respond to other status code

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,7 +13,7 @@ server {
     }
 
     location / {
-        try_files $uri $uri /index.html$is_args$args =404;
+        try_files $uri /index.html;
     }
 
     # access_log off;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helx-ui",
-  "version": "2.0.0-dev.10-test",
+  "version": "2.0.0-dev.10",
   "private": true,
   "homepage": "/static/frontend",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helx-ui",
-  "version": "2.0.0-dev.9",
+  "version": "2.0.0-dev.10-test",
   "private": true,
   "homepage": "/static/frontend",
   "dependencies": {

--- a/src/views/workspaces/active.js
+++ b/src/views/workspaces/active.js
@@ -67,7 +67,7 @@ export const ActiveView = () => {
                     openNotificationWithIcon('error', 'Error', 'An error has occurred while loading app configuration.')
                 })
         }
-        if(instances && instances.length === 0) setTimeout(() => navigate('/helx/workspaces/available'), 1000)
+        if (instances && instances.length === 0) setTimeout(() => navigate('/helx/workspaces/available'), 1000)
         else loadAppsConfig();
 
     }, [instances])
@@ -77,7 +77,6 @@ export const ActiveView = () => {
         addOrDeleteInstanceTab("close", currentRecord.sid);
         await stopInstance(currentRecord.sid)
             .then(r => {
-                setRefresh(!refresh)
                 let newActivity = {
                     'sid': 'none',
                     'app_name': currentRecord.name,
@@ -86,14 +85,32 @@ export const ActiveView = () => {
                     'message': `${currentRecord.name} is stopped.`
                 }
                 addActivity(newActivity)
+                setRefresh(!refresh)
             })
             .catch(e => {
                 let newActivity = {
                     'sid': 'none',
                     'app_name': currentRecord.name,
-                    'status': 'error',
+                    'status': '',
                     'timestamp': new Date(),
-                    'message': `An error has occurred while stopping ${currentRecord.name}.`
+                    'message': ``
+                }
+                switch (e.response.status) {
+                    case 403: {
+                        newActivity['status'] = 'error'
+                        newActivity['message'] = `Sorry, you don't have the permission to stop this instance.`
+                        break;
+                    }
+                    case 404: {
+                        newActivity['status'] = 'warning'
+                        newActivity['message'] = `${currentRecord.name} no longer exists.`
+                        setTimeout(() => setRefresh(!refresh), 1000)
+                        break;
+                    }
+                    default: {
+                        newActivity['status'] = 'error'
+                        newActivity['message'] = `An error has occurred while stopping ${currentRecord.name}.`
+                    }
                 }
                 addActivity(newActivity)
             })

--- a/src/views/workspaces/available.js
+++ b/src/views/workspaces/available.js
@@ -38,7 +38,6 @@ export const AvailableView = () => {
 
     useEffect(() => {
         const filterApps = async (a) => {
-            // timeout 1 second before we load instance list
             const instance_result = await loadInstances()
                 .then(r => {
                     setRunningInstances(r.data);
@@ -48,7 +47,7 @@ export const AvailableView = () => {
                 })
             setLoading(false);
         }
-        setTimeout(filterApps(), 1000);
+        filterApps()
     }, [apps])
 
     useEffect(() => {


### PR DESCRIPTION
This pr includes the following changes
- UI will react to status code `403` when the instance is not created by the one requesting the delete, which won't normally happen 
- UI will react to status code `404` when the instance no longer exists

![image](https://user-images.githubusercontent.com/33065086/140383425-3725867f-5c9d-4949-9767-d4e5001923d8.png)


Got it deployed on my namespace if you want to take a look: https://helx-dev-zbo.apps.renci.org/