### PR TITLE
Conditional rendering of support page components

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,5 +11,5 @@ REACT_APP_TRANQL_ENABLED='true'
 # Brand setting if HeLx Appstore is disabled. <braini, catalyst, heal, scidas, eduhelx>
 REACT_APP_UI_BRAND_NAME='catalyst'
 
-# Hide support page section if necessary. <community, documentation>
-REACT_APP_HIDDEN_SUPPORT_SECTION=[]
+# Hide support page sections if necessary. <'community', 'documentation'>
+REACT_APP_HIDDEN_SUPPORT_SECTIONS=[]

--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,8 @@ REACT_APP_WORKSPACES_ENABLED='false'
 REACT_APP_ANALYTICS='{ "platform": "mixpanel", "enabled": false, "auth": { "mixpanel_token": "", "ga_property": "" } }'
 REACT_APP_TRANQL_ENABLED='true'
 
-# Brand setting if HeLx Appstore is disabled <braini, catalyst, heal, scidas, eduhelx>
+# Brand setting if HeLx Appstore is disabled. <braini, catalyst, heal, scidas, eduhelx>
 REACT_APP_UI_BRAND_NAME='catalyst'
-REACT_APP_UI_BRAND_LOGO='https://raw.githubusercontent.com/helxplatform/appstore/b2cb2bf88c5fbca95534611737fdf78c5afb7bac/appstore/core/static/images/catalyst/bdc-logo.svg'
+
+# Hide support page section if necessary. <community, documentation>
+REACT_APP_HIDDEN_SUPPORT_SECTION=[]

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -12,6 +12,7 @@ search_url="${REACT_APP_HELX_SEARCH_URL}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
 tranql_enabled="${REACT_APP_TRANQL_ENABLED:-false}"
 analytics="${REACT_APP_ANALYTICS:-0c39f8410fd548bfa1976957d0248289}"
+hidden_support_section=${REACT_APP_HIDDEN_SUPPORT_SECTION}
 
 
 template='{
@@ -28,7 +29,8 @@ template='{
       "mixpanel_token": "%ANALYTICS%",
       "ga_property": ""
       }
-    }
+    },
+    "hidden_support_section": %HIDDEN_SUPPORT_SECTION%
 }'
 
 echo $template | sed \
@@ -36,6 +38,7 @@ echo $template | sed \
   -e "s/%SEARCH_ENABLED%/$search_enabled/" \
   -e "s/%SEARCH_URL%/$search_url/" \
   -e "s/%BRAND%/$brand_name/" \
+  -e "s/%HIDDEN_SUPPORT_SECTION%/$hidden_support_section/" \
   -e "s/%ANALYTICS%/$analytics/" \
   -e "s/%TRANQL_ENABLED%/$tranql_enabled/" \
   > $1

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -12,7 +12,7 @@ search_url="${REACT_APP_HELX_SEARCH_URL}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
 tranql_enabled="${REACT_APP_TRANQL_ENABLED:-false}"
 analytics="${REACT_APP_ANALYTICS:-0c39f8410fd548bfa1976957d0248289}"
-hidden_support_sections=${REACT_APP_HIDDEN_SUPPORT_SECTIONS}
+hidden_support_sections="${REACT_APP_HIDDEN_SUPPORT_SECTIONS}"
 
 
 template='{
@@ -30,7 +30,7 @@ template='{
       "ga_property": ""
       }
     },
-    "hidden_support_sections": %HIDDEN_SUPPORT_SECTIONS%
+    "hidden_support_sections": "%HIDDEN_SUPPORT_SECTIONS%"
 }'
 
 echo $template | sed \

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -12,7 +12,7 @@ search_url="${REACT_APP_HELX_SEARCH_URL}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
 tranql_enabled="${REACT_APP_TRANQL_ENABLED:-false}"
 analytics="${REACT_APP_ANALYTICS:-0c39f8410fd548bfa1976957d0248289}"
-hidden_support_section=${REACT_APP_HIDDEN_SUPPORT_SECTION}
+hidden_support_sections=${REACT_APP_HIDDEN_SUPPORT_SECTIONS}
 
 
 template='{
@@ -30,7 +30,7 @@ template='{
       "ga_property": ""
       }
     },
-    "hidden_support_section": %HIDDEN_SUPPORT_SECTION%
+    "hidden_support_sections": %HIDDEN_SUPPORT_SECTIONS%
 }'
 
 echo $template | sed \
@@ -38,7 +38,7 @@ echo $template | sed \
   -e "s/%SEARCH_ENABLED%/$search_enabled/" \
   -e "s/%SEARCH_URL%/$search_url/" \
   -e "s/%BRAND%/$brand_name/" \
-  -e "s/%HIDDEN_SUPPORT_SECTION%/$hidden_support_section/" \
+  -e "s/%HIDDEN_SUPPORT_SECTIONS%/$hidden_support_sections/" \
   -e "s/%ANALYTICS%/$analytics/" \
   -e "s/%TRANQL_ENABLED%/$tranql_enabled/" \
   > $1

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -64,6 +64,9 @@ export const EnvironmentProvider = ({ children }) => {
       url: `${relativeHost}/static/frontend/env.json`
     })
     let context = response.data;
+
+    // split the comma-separated string which tells ui the support section to hide
+    context.hidden_support_sections = context.hidden_support_sections.split(',')
     switch (context.brand) {
       case 'braini':
         context.logo_url = 'https://raw.githubusercontent.com/helxplatform/appstore/develop/appstore/core/static/images/braini/braini-lg-gray.png'

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -29,8 +29,8 @@ export const SupportView = () => {
 
   return (
     <Fragment>
-      {Array.isArray(context.hidden_support_section) && !context.hidden_support_section.includes('community') && <CommunitySupport />}
-      {Array.isArray(context.hidden_support_section) && !context.hidden_support_section.includes('documentation') && <Documentation />}
+      {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('community') && <CommunitySupport />}
+      {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('documentation') && <Documentation />}
     </Fragment>
   )
 }

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
 import { Typography } from 'antd'
+import { useEnvironment } from '../contexts'
 
 const { Title } = Typography
 
@@ -24,11 +25,12 @@ const Documentation = () =>
   </Fragment>
 
 export const SupportView = () => {
+  const { context } = useEnvironment()
 
   return (
     <Fragment>
-      <CommunitySupport />
-      <Documentation />
+      {!context.hidden_support_section.includes('community') && <CommunitySupport />}
+      {!context.hidden_support_section.includes('documentation') && <Documentation />}
     </Fragment>
   )
 }

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -1,30 +1,34 @@
 import { Fragment } from 'react'
 import { Typography } from 'antd'
-import { Breadcrumbs } from '../components/layout'
 
 const { Title } = Typography
 
+const CommunitySupport = () =>
+  <Fragment>
+    <Title level={1}>Community Support</Title>
+    <Typography>Your HeLx community has access to it's own Discourse, a community-driven forum that provides help and guidance to any HeLx question you may have. On Discourse, you will find members of the HeLx engineering and product management team, as well as other members of your community. Here you can ask questions, answer questions, and engage in community-building for your specific instance of HeLx.</Typography>
+    <br />
+    <Typography>Please visit <a href="https://community.helx.renci.org/invites/B2dnCA8xRi" target="_blank" rel="noopener noreferrer">community.helx.renci.org</a> today to create your account, and to join in the discourse!</Typography>
+  </Fragment>
+
+const Documentation = () =>
+  <Fragment>
+    <Title level={1}>Documentation</Title>
+    <Typography>Our documentation is designed to help guide you through your first steps with HeLx. We encourage you to get started with these introductory guides</Typography>
+    <ul>
+      <li><a href="https://helx.gitbook.io/helx-documentation/helx/starting-an-existing-app" target="_blank" rel="noopener noreferrer"><b>Logging in and starting an app</b></a> - Authentication requires a <a href="https://github.com/" target="_blank" rel="noopener noreferrer"><b>Github</b></a> or <a href="https://accounts.google.com/SignUp?hl=en" target="_blank" rel="noopener noreferrer"><b>Google</b></a> account</li>
+      <li><a href="https://helx.gitbook.io/helx-documentation/helx/application-management" target="_blank" rel="noopener noreferrer"><b>Managing your apps</b></a> - Learn how to change GPU and CPU resources, rename an app instance, and delete your running apps</li>
+      <li><a href="https://helx.gitbook.io/helx-documentation/dug/using-search" target="_blank" rel="noopener noreferrer"><b>Using search</b></a> - Familiarize yourself with Dug, the HeLx search space</li>
+      <li><a href="https://helx.gitbook.io/helx-documentation/dug/technical-documents" target="_blank" rel="noopener noreferrer"><b>More technical documentation</b></a> - Dive deeper into the HeLx platform and the underlying architecture</li>
+    </ul>
+  </Fragment>
+
 export const SupportView = () => {
-  const breadcrumbs = [
-    { text: 'Home', path: '/helx' },
-    { text: 'Support', path: '/support' },
-  ]
 
   return (
     <Fragment>
-      <Breadcrumbs crumbs={breadcrumbs} />
-      <Title level={1}>Community Support</Title>
-      <Typography>Your HeLx community has access to it's own Discourse, a community-driven forum that provides help and guidance to any HeLx question you may have. On Discourse, you will find members of the HeLx engineering and product management team, as well as other members of your community. Here you can ask questions, answer questions, and engage in community-building for your specific instance of HeLx.</Typography>
-      <br />
-      <Typography>Please visit <a href="https://community.helx.renci.org/invites/B2dnCA8xRi" target="_blank" rel="noopener noreferrer">community.helx.renci.org</a> today to create your account, and to join in the discourse!</Typography>
-      <Title level={1}>Documentation</Title>
-      <Typography>Our documentation is designed to help guide you through your first steps with HeLx. We encourage you to get started with these introductory guides</Typography>
-      <ul>
-        <li><a href="https://helx.gitbook.io/helx-documentation/helx/starting-an-existing-app" target="_blank" rel="noopener noreferrer"><b>Logging in and starting an app</b></a> - Authentication requires a <a href="https://github.com/" target="_blank" rel="noopener noreferrer"><b>Github</b></a> or <a href="https://accounts.google.com/SignUp?hl=en" target="_blank" rel="noopener noreferrer"><b>Google</b></a> account</li>
-        <li><a href="https://helx.gitbook.io/helx-documentation/helx/application-management" target="_blank" rel="noopener noreferrer"><b>Managing your apps</b></a> - Learn how to change GPU and CPU resources, rename an app instance, and delete your running apps</li>
-        <li><a href="https://helx.gitbook.io/helx-documentation/dug/using-search" target="_blank" rel="noopener noreferrer"><b>Using search</b></a> - Familiarize yourself with Dug, the HeLx search space</li>
-        <li><a href="https://helx.gitbook.io/helx-documentation/dug/technical-documents" target="_blank" rel="noopener noreferrer"><b>More technical documentation</b></a> - Dive deeper into the HeLx platform and the underlying architecture</li>
-      </ul>
+      <CommunitySupport />
+      <Documentation />
     </Fragment>
   )
 }

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -29,8 +29,8 @@ export const SupportView = () => {
 
   return (
     <Fragment>
-      {!context.hidden_support_section.includes('community') && <CommunitySupport />}
-      {!context.hidden_support_section.includes('documentation') && <Documentation />}
+      {Array.isArray(context.hidden_support_section) && !context.hidden_support_section.includes('community') && <CommunitySupport />}
+      {Array.isArray(context.hidden_support_section) && !context.hidden_support_section.includes('documentation') && <Documentation />}
     </Fragment>
   )
 }


### PR DESCRIPTION
This pr removes the breadcrumb and allows users to hide 'Community Support' or 'Documentation' section on the `/support` page. (i.e. for bdc, we don't have Community Support/discourse ).

This requires a new env variable `hidden_support_section` to be added to the ui-chart.
related PR: https://github.com/helxplatform/ui-chart/pull/9