### PR TITLE
Fix urls pointing to old app-support-prototype repository

### DIFF
--- a/src/components/workspaces/app-card.js
+++ b/src/components/workspaces/app-card.js
@@ -75,7 +75,7 @@ export const AppCard = ({ name, app_id, description, detail, docs, status, minim
     }
 
     const getLogoUrl = (app_id) => {
-        return `https://github.com/helxplatform/app-support-prototype/raw/master/dockstore-yaml-proposals/${app_id}/icon.png`
+        return `https://github.com/helxplatform/helx-apps/raw/master/app-specs/${app_id}/icon.png`
     }
 
     return (

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -15,7 +15,7 @@ export const SplashScreenView = (props) => {
     const [count, setCount] = useState(0);
 
     const decoded_url = decodeURIComponent(props.app_url);
-    const app_icon = `https://github.com/helxplatform/app-support-prototype/raw/master/dockstore-yaml-proposals/${props.app_name}/icon.png`
+    const app_icon = `https://github.com/helxplatform/helx-apps/raw/master/app-specs/${props.app_name}/icon.png`
 
     const getUrl = async () => {
         await axios.get(decoded_url)


### PR DESCRIPTION
Changed to corresponding urls in the `helx-apps` repo.

Ex: `https://github.com/helxplatform/app-support-prototype/raw/master/dockstore-yaml-proposals/cloud-top/icon.png` becomes `https://github.com/helxplatform/helx-apps/raw/master/app-specs/cloud-top/icon.png`