### PR TITLE
Ephemeral storage reduction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "4Gi"
+        ephemeral-storage: "3Gi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "2Gi"
+        ephemeral-storage: "1Gi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "4Gi"
+        ephemeral-storage: "1Gi"
     command:
     - /busybox/cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "3Gi"
+        ephemeral-storage: "2Gi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "8Gi"
+        ephemeral-storage: "4Gi"
     command:
     - /busybox/cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "1Gi"
+        ephemeral-storage: "2Gi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "1Gi"
+        ephemeral-storage: "2Gi"
     command:
     - /busybox/cat
     tty: true


### PR DESCRIPTION
Was able to build the helx-ui image with Jenkins with the ephemeral storage requests and limits set to 2Gi.  Tried 1Gi but that didn't work.  There might be a value between 1-2Gi that will also work.   Building is something that should be pretty constant when it comes to the resources.  I think setting the limits and requests to be the same is ok to do for this.