### PR TITLE
View/Page Titles

### DIFF
--- a/src/views/loading.js
+++ b/src/views/loading.js
@@ -1,7 +1,11 @@
+import { useEffect } from "react";
 import { Spin } from "antd";
 
 export const LoadingView = () => {
+    useEffect(() => {
+        document.title = `HeLx UI`
+    }, [])
     return (
-        <Spin style={{ position: 'absolute', left:0, bottom: 0, right: 0 }} />
+        <Spin style={{ position: 'absolute', left: '50%', bottom: '50%', transform: 'translate(-50%, -50%)' }} />
     )
 }

--- a/src/views/not-found.js
+++ b/src/views/not-found.js
@@ -1,9 +1,12 @@
-import { Fragment } from 'react'
+import { Fragment, useEffect } from 'react'
 import { Typography } from 'antd'
 
 const { Title } = Typography
 
 export const NotFoundView = () => {
+  useEffect(() => {
+    document.title = `Not Found · HeLx UI`
+  }, [])
   return (
     <Fragment>
       <Title level={ 1 }>ERROR 404</Title>

--- a/src/views/search.js
+++ b/src/views/search.js
@@ -1,18 +1,33 @@
-import { Fragment } from 'react'
-import { HelxSearch, SearchForm, ConceptSearchResults } from '../components/search'
+import { Fragment, useEffect } from 'react'
+import { HelxSearch, SearchForm, ConceptSearchResults, useHelxSearch } from '../components/search'
 import { Typography } from 'antd'
 import { Breadcrumbs } from '../components/layout'
 import { useEnvironment } from '../contexts'
 
 const { Title } = Typography
 
-export const SearchView = () => {
+export const SearchView = () => (
+  <HelxSearch>
+    <ScopedSearchView />
+  </HelxSearch>
+)
+
+const ScopedSearchView = () => {
   const { context } = useEnvironment();
+  const { query } = useHelxSearch()
 
   const breadcrumbs = [
     { text: 'Home', path: '/helx' },
     { text: 'Search', path: '/search' },
   ]
+
+  useEffect(() => {
+    if (query) {
+      document.title = `Search · ${query} · HeLx UI`
+    } else {
+      document.title = `HeLx UI`
+    }
+  }, [query])
 
   return (
     <Fragment>
@@ -21,9 +36,7 @@ export const SearchView = () => {
 
       {context.workspaces_enabled === 'true' && <Title level={1}>Search</Title>}
 
-      <HelxSearch>
-        <ConceptSearchResults />
-      </HelxSearch>
+      <ConceptSearchResults />
 
     </Fragment>
   )

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -32,6 +32,10 @@ export const SplashScreenView = (props) => {
     }
 
     useEffect(() => {
+        document.title = `Connecting · HeLx UI`
+    }, [])
+
+    useEffect(() => {
         try {
             const callGetUrl = async () => {
                 await getUrl();

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, useEffect } from 'react'
 import { Typography } from 'antd'
 import { useEnvironment } from '../contexts'
 
@@ -28,6 +28,10 @@ const Documentation = () =>
 
 export const SupportView = () => {
   const { context } = useEnvironment()
+
+  useEffect(() => {
+    document.title = `Support · HeLx UI`
+  }, [])
 
   return (
     <Fragment>

--- a/src/views/workspaces/active.js
+++ b/src/views/workspaces/active.js
@@ -41,6 +41,10 @@ export const ActiveView = () => {
     ]
 
     useEffect(() => {
+        document.title = `Active Workspaces · HeLx UI`
+    }, [])
+
+    useEffect(() => {
         const renderInstance = async () => {
             setLoading(true);
             await loadInstances()

--- a/src/views/workspaces/available.js
+++ b/src/views/workspaces/available.js
@@ -22,6 +22,10 @@ export const AvailableView = () => {
     ]
 
     useEffect(() => {
+        document.title = `Workspaces · HeLx UI`
+    }, [])
+
+    useEffect(() => {
         const renderApp = async () => {
             setLoading(true)
             await loadApps()


### PR DESCRIPTION
Adds titles to each UI view instead of just the static `HeLx UI`. The format used is `{name} · HeLx UI`, with extra bullets being inserted when relevant, e.g. searches use `Search · {query} · HeLx UI`.