### PR TITLE
Fix/jenkins memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=node:node "package*.json" /usr/src/app/
 RUN npm ci --only=production
 
 COPY --chown=node:node . /usr/src/app
-RUN BUILD_PATH=./build/frontend npm run build --production --no-audit --max-old-space-size=4096
+RUN BUILD_PATH=./build/frontend NODE_OPTIONS=--max-old-space-size=4096 npm run build --production --no-audit
 
 ########################
 # Production environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=node:node "package*.json" /usr/src/app/
 RUN npm ci --only=production
 
 COPY --chown=node:node . /usr/src/app
-RUN BUILD_PATH=./build/frontend npm run build --production --no-audit
+RUN BUILD_PATH=./build/frontend npm run build --production --no-audit --max_old_space_size=4096
 
 ########################
 # Production environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=node:node "package*.json" /usr/src/app/
 RUN npm ci --only=production
 
 COPY --chown=node:node . /usr/src/app
-RUN BUILD_PATH=./build/frontend npm run build --production --no-audit --max_old_space_size=4096
+RUN BUILD_PATH=./build/frontend npm run build --production --no-audit --max-old-space-size=4096
 
 ########################
 # Production environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=node:node "package*.json" /usr/src/app/
 RUN npm ci --only=production
 
 COPY --chown=node:node . /usr/src/app
-RUN BUILD_PATH=./build/frontend NODE_OPTIONS=--max-old-space-size=4096 npm run build --production --no-audit
+RUN BUILD_PATH=./build/frontend GENERATE_SOURCEMAP=false npm run build --production --no-audit
 
 ########################
 # Production environment


### PR DESCRIPTION
Removes source map generation when building the production bundle of the app. This was using too much memory when building in Kubernetes and causing failure.