### PR TITLE
CDE tab improvements

### DIFF
--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -129,7 +129,7 @@ export const ConceptModalBody = ({ result }) => {
               const controller = new AbortController()
               fetchCdesTranqlController.current.push(controller)
               const res = await fetch(
-                  `${tranqlUrl}/tranql/query`,
+                  `${tranqlUrl}tranql/query`,
                   {
                       headers: { 'Content-Type': 'text/plain' },
                       method: 'POST',

--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -164,7 +164,11 @@ export const ConceptModalBody = ({ result }) => {
         if (cdeData) {
           const cdeIds = cdeData.elements.map((cde) => cde.id)
           await Promise.all(cdeIds.map(async (cdeId, i) => {
-            relatedConcepts[cdeId] = await loadRelatedConcepts(cdeId)
+            try {
+              relatedConcepts[cdeId] = await loadRelatedConcepts(cdeId)
+            } catch (e) {
+              relatedConcepts[cdeId] = null
+            }
           }))
         }
         setCdes(cdeData)

--- a/src/components/search/concept-modal/tabs/cdes/cde-list.js
+++ b/src/components/search/concept-modal/tabs/cdes/cde-list.js
@@ -10,8 +10,6 @@ export const CdeList = ({ cdes, cdeRelatedConcepts, highlight, loading, failed }
             description="Sorry! We couldn't find any CDEs linked to this concept."
         />
     )
-    cdes = []   
-    loading = true
     return (
         <List
             loading={{

--- a/src/components/search/concept-modal/tabs/cdes/cde-list.js
+++ b/src/components/search/concept-modal/tabs/cdes/cde-list.js
@@ -10,9 +10,15 @@ export const CdeList = ({ cdes, cdeRelatedConcepts, highlight, loading, failed }
             description="Sorry! We couldn't find any CDEs linked to this concept."
         />
     )
+    cdes = []   
+    loading = true
     return (
         <List
-            loading={loading}
+            loading={{
+                spinning: loading,
+                tip: "We're digging into data for you. Hang tight!",
+                style: { color: "rgba(0,0,0, 0.45)" }
+            }}
             dataSource={cdes}
             renderItem={(cde) => (
                 <CdeItem cde={ cde } cdeRelatedConcepts={ cdeRelatedConcepts } highlight={highlight} />

--- a/src/components/search/concept-modal/tabs/cdes/cde-list.js
+++ b/src/components/search/concept-modal/tabs/cdes/cde-list.js
@@ -7,7 +7,7 @@ export const CdeList = ({ cdes, cdeRelatedConcepts, highlight, loading, failed }
     if (failed) return (
         <Empty
             image={ Empty.PRESENTED_IMAGE_SIMPLE }
-            description="Sorry! We couldn't find any CDEs linked to this concept."
+            description="Sorry! We weren't able to find any CDEs linked to this concept."
         />
     )
     return (

--- a/src/components/search/concept-modal/tabs/cdes/cdes.js
+++ b/src/components/search/concept-modal/tabs/cdes/cdes.js
@@ -56,7 +56,7 @@ export const CdesTab = ({ cdes, cdeRelatedConcepts, loading }) => {
         <Title level={ 4 } style={{ margin: 0 }}>CDEs</Title>
         { !failed && <DebouncedInput setValue={setSearch}/> }
       </div>
-      {/* { search && <Text style={{ display: "block", marginTop: "8px", marginBottom: "-16px" }}>Search results for <Text italic>{search.trim()}</Text>:</Text> } */}
+      {/* { search && <Text style={{ display: "block", marginTop: "8px", marginBottom: "-16px", fontSize: 15, color: "rgba(0, 0, 0, 0.45)" }}>Search results for <i>{search.trim()}</i>:</Text> } */}
       <CdeList cdes={cdeSource} cdeRelatedConcepts={cdeRelatedConcepts} highlight={highlightTokens} loading={loading} failed={failed}/>
    </Space>
   )

--- a/src/components/search/concept-modal/tabs/cdes/cdes.js
+++ b/src/components/search/concept-modal/tabs/cdes/cdes.js
@@ -54,7 +54,7 @@ export const CdesTab = ({ cdes, cdeRelatedConcepts, loading }) => {
     <Space direction="vertical">
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <Title level={ 4 } style={{ margin: 0 }}>CDEs</Title>
-        { !failed && <DebouncedInput setValue={setSearch}/> }
+        { !failed && !loading && <DebouncedInput setValue={setSearch}/> }
       </div>
       {/* { search && <Text style={{ display: "block", marginTop: "8px", marginBottom: "-16px", fontSize: 15, color: "rgba(0, 0, 0, 0.45)" }}>Search results for <i>{search.trim()}</i>:</Text> } */}
       <CdeList cdes={cdeSource} cdeRelatedConcepts={cdeRelatedConcepts} highlight={highlightTokens} loading={loading} failed={failed}/>

--- a/src/components/search/concept-modal/tabs/cdes/cdes.js
+++ b/src/components/search/concept-modal/tabs/cdes/cdes.js
@@ -27,7 +27,7 @@ export const CdesTab = ({ cdes, cdeRelatedConcepts, loading }) => {
         // Lunr supports array fields, though it expects the user to tokenize the elements themselves.
         // Instead, just join the concepts into a string and let lunr tokenize it instead.
         // See: https://stackoverflow.com/a/43562885
-        concepts: Object.values(cdeRelatedConcepts[cde.id]).map((concept) => concept.name).join(" ")
+        concepts: Object.values(cdeRelatedConcepts[cde.id] ?? []).map((concept) => concept.name).join(" ")
       }))
     } else return []
   }, [loading, failed, cdes, cdeRelatedConcepts])

--- a/src/components/search/concept-modal/tabs/cdes/related-concepts/related-concepts-list.js
+++ b/src/components/search/concept-modal/tabs/cdes/related-concepts/related-concepts-list.js
@@ -10,6 +10,9 @@ const SHOW_COUNT = 8
 export const RelatedConceptsList = ({ concepts, highlight }) => {
     const [showingAll, setShowingAll] = useState(false)
 
+    const failed = useMemo(() => concepts === null, [concepts])
+    if (failed) concepts = []
+
     const showCount = useMemo(() => showingAll ? concepts.length : SHOW_COUNT, [showingAll, concepts])
     const hideShowAll = useMemo(() => concepts.length <= SHOW_COUNT, [concepts])
 
@@ -18,6 +21,10 @@ export const RelatedConceptsList = ({ concepts, highlight }) => {
     const hiddenHighlighted = hiddenConcepts.filter((concept) => (
         highlight.some((token) => concept.name.includes(token))
     ))
+
+    if (failed) return (
+        <Text style={{ fontSize: 13, color: "rgba(0, 0, 0, 0.45)" }}>We couldn't load any related concepts.</Text>
+    )
 
     return (
         <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "8px", marginTop: "4px" }}>

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -87,6 +87,9 @@ export const EnvironmentProvider = ({ children }) => {
       // split the comma-separated string which tells ui the support section to hide
       context.hidden_support_sections = context.hidden_support_sections.split(',')
 
+      // Make sure the tranql_url ends with a slash. If it doesn't, it will redirect, which breaks the iframe for some reason. 
+      if (!context.tranql_url.endsWith("/")) context.tranql_url += "/"
+
       // logos for different brands. Use the helx logo if no brand has been specified.
       let brandAssetFolder = context.brand
       // `catalyst` is the supported name, but support `cat` and `bdc` as well.


### PR DESCRIPTION
- FIx CDE tranql url (was appending an extra trailing slash)
  - Also, a forward slash will automatically be appended to `context.tranql_url` if it is omitted in the env.json now.
- Add loading text to CDE spinner (DUG-184)
- Adds proper handling for when CDEs fail to load related concepts
- Hides the search bar while loading