### PR TITLE
Automaticaly set extraLinks to an empty array if null in branding con…

### DIFF
--- a/src/contexts/workspaces-context/api.ts
+++ b/src/contexts/workspaces-context/api.ts
@@ -198,7 +198,9 @@ export class WorkspacesAPI implements IWorkspacesAPI {
     @APIRequest()
     async getEnvironmentContext(fetchOptions: AxiosRequestConfig={}): Promise<EnvironmentContextResponse> {
         const res = await this.axios.get<EnvironmentContextResponse>("/context/", fetchOptions)
-        return res.data
+        const { data } = res;
+        if (data.links === null) data.links = []
+        return data
     }
 
     @APIRequest(Throws403)


### PR DESCRIPTION
Some brands in Appstore may define extra links to be `none`, instead of an empty list. Make sure it's an empty list even if defined as null in the branding context.