### PR TITLE
Fix the CCV for the release and the commit-msg git hook for breaking changes

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -61,21 +61,21 @@ if [ "$yesno" == "y" ] || [ "$yesno" == "yes" ]; then
     breaking_commit=1
 fi
 
-NL=$'\n'
 if [ "$breaking_commit" -eq 1 ]; then
-    # Explicitly state it's a breaking change
-    msg="$msg${NL}${NL}BREAKING CHANGE"
+    # Prepend commit type to original commit text.
+    final_msg="${commit_type}!: BREAKING CHANGE. $orig_msg";
+else
+    # Prepend commit type to original commit text.
+    final_msg="${commit_type}: $orig_msg";
 fi
 
-# Prepend commit type to original commit text.
-new_msg="${commit_type}: $orig_msg";
-echo $new_msg > $1;
+echo $final_msg > $1;
 
 echo
 echo "Updated message:"
 echo
 echo "--------------------------------------------------------------------------------"
-echo "$new_msg"
+echo "$final_msg"
 echo "--------------------------------------------------------------------------------"
 echo
 exit 0


### PR DESCRIPTION
The included commit that has a `!` right before the colon in the beginning of the commit message will trigger the breaking change in CCV, according to this: https://www.conventionalcommits.org/en/v1.0.0/#summary

I also confirmed it will work in the code of the CCV library we're using here: https://github.com/smlx/ccv/blob/main/main.go