### PR TITLE
Add useTitle hook to views

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,3 +1,4 @@
+export * from './view'
 export * from './support'
 export * from './not-found'
 export * from './not-authorized'

--- a/src/views/loading.js
+++ b/src/views/loading.js
@@ -1,10 +1,11 @@
 import { useEffect } from "react";
 import { Spin } from "antd";
+import { withView } from "./";
+import { useTitle } from "./view";
 
 export const LoadingView = () => {
-    useEffect(() => {
-        document.title = `HeLx UI`
-    }, [])
+    useTitle("")
+    
     return (
         <Spin style={{ position: 'absolute', left: '50%', bottom: '50%', transform: 'translate(-50%, -50%)' }} />
     )

--- a/src/views/not-authorized.js
+++ b/src/views/not-authorized.js
@@ -1,12 +1,12 @@
 import { Fragment, useEffect } from 'react'
 import { Typography } from 'antd'
+import { useTitle } from './'
 
 const { Title, Paragraph } = Typography
 
 export const NotAuthorizedView = () => {
-  useEffect(() => {
-    document.title = `Not Authorized · HeLx UI`
-  }, [])
+  useTitle("Not Authorized")
+
   return (
     <Fragment>
       <Title level={ 1 }>ERROR 401</Title>

--- a/src/views/not-found.js
+++ b/src/views/not-found.js
@@ -2,6 +2,7 @@ import { Fragment, useEffect } from 'react'
 import { Button, Result, Typography } from 'antd'
 import { useNavigate } from '@gatsbyjs/reach-router'
 import { useEnvironment } from '../contexts'
+import { useTitle } from './'
 
 const { Title } = Typography
 
@@ -9,9 +10,8 @@ export const NotFoundView = () => {
   const { basePath } = useEnvironment()
   const navigate = useNavigate()
 
-  useEffect(() => {
-    document.title = `Not Found · HeLx UI`
-  }, [])
+  useTitle("Not Found")
+
   return (
     <Fragment>
       <Result

--- a/src/views/search.js
+++ b/src/views/search.js
@@ -3,6 +3,7 @@ import { HelxSearch, SearchForm, Results, useHelxSearch } from '../components/se
 import { Typography } from 'antd'
 import { Breadcrumbs } from '../components/layout'
 import { useEnvironment } from '../contexts'
+import { useTitle } from './'
 
 const { Title } = Typography
 
@@ -21,13 +22,8 @@ const ScopedSearchView = () => {
     { text: 'Search', path: '/search' },
   ]
 
-  useEffect(() => {
-    if (query) {
-      document.title = `Search · ${query} · HeLx UI`
-    } else {
-      document.title = `HeLx UI`
-    }
-  }, [query])
+  // We need to override the withView useTitle since we have dynamic needs here.
+  useTitle(query ? ["Search", query] : "")
 
   return (
     <Fragment>

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -3,6 +3,8 @@ import { Spin, Button } from "antd";
 import axios from "axios";
 import { callWithRetry } from "../utils";
 import { useEnvironment } from '../contexts';
+import { withView } from './';
+import { useTitle } from "./view";
 
 // This view is used when the UI is checking the readiness of an instance
 
@@ -17,10 +19,8 @@ export const SplashScreenView = (props) => {
 
     const decoded_url = decodeURIComponent(props.app_url);
     const app_icon = `${context.dockstore_app_specs_dir_url}/${props.app_name}/icon.png`
-
-    useEffect(() => {
-        document.title = `Connecting · HeLx UI`
-    }, [])
+    
+    useTitle("Connecting")
 
     useEffect(() => {
         let shouldCancel = false;

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -1,6 +1,7 @@
 import { Fragment, useEffect } from 'react'
 import { Typography } from 'antd'
 import { useEnvironment } from '../contexts'
+import { useTitle } from './'
 
 const { Title } = Typography
 
@@ -28,10 +29,7 @@ const Documentation = () =>
 
 export const SupportView = () => {
   const { context } = useEnvironment()
-
-  useEffect(() => {
-    document.title = `Support · HeLx UI`
-  }, [])
+  useTitle("Support")
 
   return (
     <Fragment>

--- a/src/views/view.tsx
+++ b/src/views/view.tsx
@@ -5,6 +5,12 @@ interface ViewProps {
     title: string | string[] | null
 }
 
+/** Notes:
+ * An empty string "" or empty array will just use the "Helx UI" component as the title.
+ * A null value will not update the title. It disables the hook. This may be useful in components
+ *  that wrap views conditionally, e.g. loading view that wraps other views.
+ * The "HeLx UI" component is appended to the end of all titles, does not need to be included.
+ */
 export const useTitle = (title: string | string[] | null) => {
     if (title === "") title = []
     const titleSegments = Array.isArray(title) ? title : [title]

--- a/src/views/view.tsx
+++ b/src/views/view.tsx
@@ -1,0 +1,24 @@
+import { ComponentType, useEffect } from 'react'
+
+interface ViewProps {
+    // Note: a null title is equivalent to an empty string or empty array, it will just display "HeLx UI" as the title.
+    title: string | string[] | null
+}
+
+export const useTitle = (title: string | string[] | null) => {
+    if (title === "") title = []
+    const titleSegments = Array.isArray(title) ? title : [title]
+    useEffect(() => {
+        if (title !== null) document.title = [...titleSegments, "HeLx UI"].join(" · ")
+    }, [titleSegments])
+}
+
+// export function withView<T extends object>(
+//     View: ComponentType<T>,
+//     { title }: ViewProps
+// ) {
+//     return (props: T) => {
+//         useTitle(title)
+//         return <View { ...props } />
+//     }
+// }

--- a/src/views/workspaces/active.js
+++ b/src/views/workspaces/active.js
@@ -10,6 +10,7 @@ import { toBytes, bytesToMegabytes, formatBytes } from '../../utils/memory-conve
 import { updateTabName } from '../../utils/update-tab-name';
 import { withWorkspaceAuthentication } from '.';
 import { navigate } from '@gatsbyjs/reach-router';
+import { useTitle } from '..';
 
 const memoryFormatter = (value) => {
     return formatBytes(value, 2);
@@ -41,9 +42,7 @@ export const ActiveView = withWorkspaceAuthentication(() => {
         { text: 'Active', path: '/helx/workspaces/active' },
     ]
 
-    useEffect(() => {
-        document.title = `Active Workspaces · HeLx UI`
-    }, [])
+    useTitle("Active Workspaces")
 
     useEffect(() => {
         const renderInstance = async () => {

--- a/src/views/workspaces/available.js
+++ b/src/views/workspaces/available.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react'
 import { Layout, Col, Spin } from 'antd'
 import { withWorkspaceAuthentication, WorkspaceProtectedView } from './'
+import { withView } from '../'
 import { AppCard } from '../../components/workspaces'
 import { NavigationTabGroup } from '../../components/workspaces/navigation-tab-group'
 import { useApp, useEnvironment, useInstance, useWorkspacesAPI } from '../../contexts'
 import { openNotificationWithIcon } from '../../components/notifications';
 import { Breadcrumbs } from '../../components/layout'
 import '../../components/workspaces/app-card.css'
+import { useTitle } from '../view'
 
 
 export const AvailableView = withWorkspaceAuthentication(() => {
@@ -22,9 +24,7 @@ export const AvailableView = withWorkspaceAuthentication(() => {
         { text: 'Available', path: '/helx/workspaces/available' },
     ]
 
-    useEffect(() => {
-        document.title = `Workspaces · HeLx UI`
-    }, [])
+    useTitle("Workspaces")
 
     useEffect(() => {
         const renderApp = async () => {

--- a/src/views/workspaces/login/login-success-redirect.js
+++ b/src/views/workspaces/login/login-success-redirect.js
@@ -2,11 +2,14 @@ import { useEffect, useMemo } from 'react'
 import { Result } from 'antd'
 import { useLocation } from '@gatsbyjs/reach-router'
 import { useDest, useEnvironment } from '../../../contexts'
+import { useTitle } from '../..'
 
 export const LoginSuccessRedirectView = ({ }) => {
     const location = useLocation()
     const { basePath } = useEnvironment()
     const { redirectToDest } = useDest()
+
+    useTitle("Login")
 
     const delay = useMemo(() => {
         const redirectDelay = new URLSearchParams(location.search).get("redirect_delay")
@@ -22,10 +25,6 @@ export const LoginSuccessRedirectView = ({ }) => {
             clearTimeout(timeout)
         }
     }, [location.search, delay])
-
-    useEffect(() => {
-        document.title = `Login · HeLx UI`
-    }, [])
 
     return (
         <div>

--- a/src/views/workspaces/login/login.js
+++ b/src/views/workspaces/login/login.js
@@ -10,6 +10,7 @@ import { withAPIReady } from '../'
 import { useDest, useEnvironment, useWorkspacesAPI } from '../../../contexts'
 import '@ant-design/pro-form/dist/form.css'
 import  './login.css'
+import { useTitle } from '../..'
 
 const { Title, Text, Paragraph } = Typography
 const { useForm } = Form
@@ -73,6 +74,8 @@ export const WorkspaceLoginView = withAPIReady(({
     const { api, user, loginProviders } = useWorkspacesAPI()
     const { redirectToDest, redirectWithCurrentDest } = useDest()
 
+    useTitle("Login")
+
     const allowBasicLogin = useMemo(() => loginProviders.includes("Django"), [loginProviders])
     const allowUncLogin =  useMemo(() => loginProviders.includes("UNC Chapel Hill Single Sign-On"), [loginProviders])
     const allowGoogleLogin = useMemo(() => loginProviders.includes("Google"), [loginProviders])
@@ -99,10 +102,6 @@ export const WorkspaceLoginView = withAPIReady(({
             redirectToDest(`${ basePath }workspaces/`)
         }
     }, [user])
-
-    useEffect(() => {
-        document.title = `Login · HeLx UI`
-    }, [])
 
     const validateForm = async () => {
         setCurrentlyValidating(true)

--- a/src/views/workspaces/login/signup.js
+++ b/src/views/workspaces/login/signup.js
@@ -11,6 +11,7 @@ import { useDest, useEnvironment, useWorkspacesAPI } from '../../../contexts'
 import '@ant-design/pro-form/dist/form.css'
 import  './login.css'
 import { SocialSignupNotAuthorizedError } from '../../../contexts/workspaces-context/api.types'
+import { useTitle } from '../..'
 
 const { Title, Text, Paragraph } = Typography
 const { useForm } = Form
@@ -58,6 +59,8 @@ export const WorkspaceSignupView = withSocialSignupAllowed(({
     const { api, user, loginProviders } = useWorkspacesAPI()
     const { redirectToDest, redirectWithCurrentDest } = useDest()
 
+    useTitle("Signup")
+
     useEffect(() => {
         if (revalidateForm) {
             form.validateFields()
@@ -73,10 +76,6 @@ export const WorkspaceSignupView = withSocialSignupAllowed(({
             redirectToDest(`${ basePath }workspaces/`)
         }
     }, [user])
-
-    useEffect(() => {
-        document.title = `Signup · HeLx UI`
-    }, [])
 
     const validateForm = async () => {
         setCurrentlyValidating(true)

--- a/src/views/workspaces/workspace-protected-view.js
+++ b/src/views/workspaces/workspace-protected-view.js
@@ -1,8 +1,9 @@
-import React, { Fragment, useMemo } from 'react'
 import { Button, Space, Spin, Typography } from 'antd'
 import { TimeUntil, useTimeUntil } from 'react-time-until'
 import { useEnvironment, useWorkspacesAPI } from '../../contexts'
 import { ProtectedView, withAuthentication } from '../protected-view'
+import { withView } from '../'
+import { useTitle } from '../view'
 
 const { Text } = Typography
 
@@ -10,6 +11,8 @@ export const APILoadingProtectedView = ({ children }) => {
     const { loading: apiLoading, loadingBackoff } = useWorkspacesAPI()
     const timeUntil = useTimeUntil({ date: loadingBackoff, countdown: true })
     
+    useTitle(apiLoading ? "" : null)
+
     if (apiLoading) return (
         <Space direction="vertical" style={{ display: "flex", justifyContent: "center", alignItems: "center", flexDirection: "column", flex: 1 }}>
             <Spin />


### PR DESCRIPTION
This was originally supposed to add a higher-order component used by all view components, but with the only configuration needed on the view-level being the title and the need for dynamic titles in certain views, it didn't make sense as of right now. If we need more configuration for views in the future, we may want to revisit this idea.

For now, this PR just adds a useTitle hook that each view should use to set the document title when the view is active.