### PR TITLE
fix: critical bug related to mishandling stale data

### DIFF
--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -113,6 +113,7 @@ export const ConceptModalBody = ({ result }) => {
         fetchCdesController.current = new AbortController()
         fetchCdesTranqlController.current.forEach((controller) => controller.abort())
         fetchCdesTranqlController.current = []
+
         const cdeData = await fetchCDEs(result.id, query, {
           signal: fetchCdesController.current.signal
         })
@@ -167,6 +168,10 @@ export const ConceptModalBody = ({ result }) => {
             try {
               relatedConcepts[cdeId] = await loadRelatedConcepts(cdeId)
             } catch (e) {
+              // Here, we explicitly want to halt execution and forward this error to the outer handler
+              // if a related concept request was aborted, because we now have stale data and don't want to
+              // update state with it.
+              if (e.name === "CanceledError" || e.name === "AbortError") throw e
               relatedConcepts[cdeId] = null
             }
           }))


### PR DESCRIPTION
Fixes bug that would occur if a user navigated to a related CDE concept and then quickly returned to the original concept. Resulted in a page crash if the concept modal was not closed before the requests resolved.