### PR TITLE
fix: Should generally fix logout persistence error

### DIFF
--- a/src/contexts/workspaces-context/api.ts
+++ b/src/contexts/workspaces-context/api.ts
@@ -374,8 +374,8 @@ export class WorkspacesAPI implements IWorkspacesAPI {
         fetchOptions: AxiosRequestConfig={}
     ): Promise<LogoutResponse> {
         /** Log out */
-        await this._updateLoginState(null)
         const res = await this.axios.post<LogoutResponse>("/users/logout/", undefined, fetchOptions)
+        await this._updateLoginState(null)
         return null
         // try {
         // } catch (e: any) {


### PR DESCRIPTION
This fixes the issue of logout persistence errors on the UI end. They could occur if a user logged out, then sent a login request that was fulfilled at the same time their logout request was being fulfilled. They are technically still possible, but the backend work required to fix a problem that should essentially never occur in the first place is really not worth it here.