### PR TITLE
fix: Fix broken env script

### DIFF
--- a/bin/populate_env
+++ b/bin/populate_env
@@ -15,7 +15,6 @@ tranql_url="${REACT_APP_TRANQL_URL:-\/tranql}"
 analytics="${REACT_APP_ANALYTICS:-}"
 hidden_support_sections="${REACT_APP_HIDDEN_SUPPORT_SECTIONS}"
 deployment_namespace="${REACT_APP_DEPLOYMENT_NAMESPACE}"
-dockstore_app_specs_dir_url="${TYCHO_APP_REGISTRY_REPO}/${TYCHO_APP_REGISTRY_BRANCH}/${TYCHO_APP_REGISTRY_APP_SPECS_DIR}"
 appstore_asset_branch="${REACT_APP_APPSTORE_ASSET_BRANCH}"
 
 
@@ -37,7 +36,6 @@ template='{
     },
     "hidden_support_sections": "%HIDDEN_SUPPORT_SECTIONS%",
     "deployment_namespace": "%DEPLOYMENT_NAMESPACE%",
-    "dockstore_app_specs_dir_url": "%DOCKSTORE_APP_SPECS_DIR_URL%",
     "appstore_asset_branch": "%APPSTORE_ASSET_BRANCH%"
 }'
 
@@ -51,6 +49,5 @@ echo "$template" | sed \
   -e "s/%TRANQL_ENABLED%/$tranql_enabled/" \
   -e "s/%TRANQL_URL%/$tranql_url/" \
   -e "s/%DEPLOYMENT_NAMESPACE%/$deployment_namespace/" \
-  -e "s+%DOCKSTORE_APP_SPECS_DIR_URL%+$dockstore_app_specs_dir_url+" \
   -e "s/%APPSTORE_ASSET_BRANCH%/$appstore_asset_branch/" \
   > $1


### PR DESCRIPTION
Change @pj-linebaugh made I think uses wrong sed substitution, populate_env now crashes and can't generate an env file. I've gone ahead and just removed the option since it isn't useful except in the different populate_env present in appstore, and will be gone soon anyways with decoupling changes.