### PR TITLE
Fixes #284 (activity monitor may not update when two apps are launched at the same time)

### DIFF
--- a/src/contexts/activity-context.js
+++ b/src/contexts/activity-context.js
@@ -9,18 +9,20 @@ export const ActivityContext = createContext({});
 export const ActivityProvider = ({ children }) => {
     const [activityArray, setActivityArray] = useState([]);
 
-    const addActivity = new_activity => {
-        let newActivityArray = [...activityArray];
-        newActivityArray.unshift(new_activity);
-        setActivityArray(newActivityArray)
-    }
+    const addActivity = useCallback((newActivity) => {
+        setActivityArray((oldActivityArray) => (
+            [ newActivity, ...oldActivityArray ]
+        ))
+    }, [])
 
-    const updateActivity = new_activity => {
-        let filteredArray = [...activityArray];
-        filteredArray = activityArray.filter(value => { return value['sid'] !== new_activity['sid'] })
-        filteredArray.unshift(new_activity);
-        setActivityArray(filteredArray)
-    }
+    const updateActivity = useCallback((newActivity) => {
+        setActivityArray((oldActivityArray) => (
+            [
+                newActivity,
+                ...oldActivityArray.filter((value) => value['sid'] !== newActivity['sid'])
+            ]
+        ))
+    }, [])
 
     return (
         <ActivityContext.Provider


### PR DESCRIPTION
This only fixes the problem in activity monitor.

There is still an active bug where when you launch two apps at the same time, only the first app that launches will show up in the active page when you're redirected. This is because when the you open the active page, it makes a single API call to get the actively running apps, and since the second app hasn't launched yet, it won't show up. The page doesn't know that another app has been launched since then. I've left this unfixed as it is not worth the work and should be fixed by planned server-sent event updates anyways (an event should notify the ui when an app is created and the active page will observe this).