### PR TITLE
Decouple UI

### DIFF
--- a/bin/populate_env
+++ b/bin/populate_env
@@ -15,7 +15,6 @@ tranql_url="${REACT_APP_TRANQL_URL:-\/tranql}"
 analytics="${REACT_APP_ANALYTICS:-}"
 hidden_support_sections="${REACT_APP_HIDDEN_SUPPORT_SECTIONS}"
 deployment_namespace="${REACT_APP_DEPLOYMENT_NAMESPACE}"
-dockstore_app_specs_dir_url="${TYCHO_APP_REGISTRY_REPO}/${TYCHO_APP_REGISTRY_BRANCH}/${TYCHO_APP_REGISTRY_APP_SPECS_DIR}"
 appstore_asset_branch="${REACT_APP_APPSTORE_ASSET_BRANCH}"
 
 
@@ -37,7 +36,6 @@ template='{
     },
     "hidden_support_sections": "%HIDDEN_SUPPORT_SECTIONS%",
     "deployment_namespace": "%DEPLOYMENT_NAMESPACE%",
-    "dockstore_app_specs_dir_url": "%DOCKSTORE_APP_SPECS_DIR_URL%",
     "appstore_asset_branch": "%APPSTORE_ASSET_BRANCH%"
 }'
 
@@ -51,6 +49,5 @@ echo "$template" | sed \
   -e "s/%TRANQL_ENABLED%/$tranql_enabled/" \
   -e "s/%TRANQL_URL%/$tranql_url/" \
   -e "s/%DEPLOYMENT_NAMESPACE%/$deployment_namespace/" \
-  -e "s+%DOCKSTORE_APP_SPECS_DIR_URL%+$dockstore_app_specs_dir_url+" \
   -e "s/%APPSTORE_ASSET_BRANCH%/$appstore_asset_branch/" \
   > $1

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -12,7 +12,7 @@ const { useBreakpoint } = Grid
 
 export const Layout = ({ children }) => {
   const { helxAppstoreUrl, routes, context, basePath } = useEnvironment()
-  const { api, loading: apiLoading, loggedIn, extraLinks } = useWorkspacesAPI()
+  const { api, loading: apiLoading, loggedIn, environmentContext } = useWorkspacesAPI()
   const { analyticsEvents } = useAnalytics()
   const { md } = useBreakpoint()
   const baseLinkPath = context.workspaces_enabled === 'true' ? '/helx' : ''
@@ -60,7 +60,7 @@ export const Layout = ({ children }) => {
                 <Menu.Item key={`${m.path}`}><Link to={`${baseLinkPath}${m.path}`}>{m.text}</Link></Menu.Item>
               ))}
               {context.workspaces_enabled && !apiLoading && (
-                extraLinks.map((link) => (
+                environmentContext.links.map((link) => (
                   <Menu.Item key={ link.title }>
                     <LinkOutlined style={{ marginRight: 12 }} />
                     <a href={ link.link } target="_blank" rel="noopener noreferrer">

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -12,7 +12,7 @@ const { useBreakpoint } = Grid
 
 export const Layout = ({ children }) => {
   const { helxAppstoreUrl, routes, context, basePath } = useEnvironment()
-  const { api, loading: apiLoading, loggedIn, environmentContext } = useWorkspacesAPI()
+  const { api, loading: apiLoading, loggedIn, appstoreContext } = useWorkspacesAPI()
   const { analyticsEvents } = useAnalytics()
   const { md } = useBreakpoint()
   const baseLinkPath = context.workspaces_enabled === 'true' ? '/helx' : ''
@@ -60,7 +60,7 @@ export const Layout = ({ children }) => {
                 <Menu.Item key={`${m.path}`}><Link to={`${baseLinkPath}${m.path}`}>{m.text}</Link></Menu.Item>
               ))}
               {context.workspaces_enabled && !apiLoading && (
-                environmentContext.links.map((link) => (
+                appstoreContext.links.map((link) => (
                   <Menu.Item key={ link.title }>
                     <LinkOutlined style={{ marginRight: 12 }} />
                     <a href={ link.link } target="_blank" rel="noopener noreferrer">

--- a/src/components/workspaces/app-card.js
+++ b/src/components/workspaces/app-card.js
@@ -21,7 +21,7 @@ const validateLocalstorageValue = (config, app_id, min, max) => {
 }
 
 export const AppCard = ({ name, app_id, description, detail, docs, status, minimum_resources, maximum_resources, available }) => {
-    const { api } = useWorkspacesAPI();
+    const { api, appstoreContext } = useWorkspacesAPI();
     const { addActivity } = useActivity();
     const { analyticsEvents } = useAnalytics();
     const { context } = useEnvironment()
@@ -75,7 +75,7 @@ export const AppCard = ({ name, app_id, description, detail, docs, status, minim
     }
 
     const getLogoUrl = (app_id) => {
-        return `${context.dockstore_app_specs_dir_url}/${app_id}/icon.png`
+        return `${appstoreContext.dockstore_app_specs_dir_url}/${app_id}/icon.png`
     }
 
     return (

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -81,7 +81,6 @@ export const EnvironmentProvider = ({ children }) => {
       let context = response.data;
 
       /** Context defaults */
-      if (!context.dockstore_app_specs_dir_url) context.dockstore_app_specs_dir_url = "[ MISSING VALUE ]"
       if (!context.appstore_asset_branch) context.appstore_asset_branch = "master"
       if (!context.brand) context.brand = "helx"
 

--- a/src/contexts/workspaces-context/api.types.ts
+++ b/src/contexts/workspaces-context/api.types.ts
@@ -103,6 +103,7 @@ export interface EnvironmentContext {
     }
     links: ExtraLink[]
     capabilities: Capability[]
+    dockstore_app_specs_dir_url: string
     env: {
         [key: string]: any  
     }

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -5,10 +5,11 @@ import { callWithRetry } from "../utils";
 import { useEnvironment, useWorkspacesAPI } from '../contexts';
 import { withView } from './';
 import { useTitle } from "./view";
+import { withWorkspaceAuthentication } from "./workspaces";
 
 // This view is used when the UI is checking the readiness of an instance
 
-export const SplashScreenView = (props) => {
+export const SplashScreenView = withWorkspaceAuthentication((props) => {
     const header = document.getElementById('helx-header');
     const sidePanel = document.getElementById('helx-side-panel');
     if(header !== null) header.style.visibility = "hidden";
@@ -19,7 +20,11 @@ export const SplashScreenView = (props) => {
     const [errorPresent, setErrorPresent] = useState(false);
 
     const decoded_url = decodeURIComponent(props.app_url);
-    const app_icon = `${appstoreContext.dockstore_app_specs_dir_url}/${props.app_name}/icon.png`
+    const app_icon = useMemo(() => (
+        appstoreContext
+            ? `${appstoreContext.dockstore_app_specs_dir_url}/${props.app_name}/icon.png`
+            : undefined
+    ), [appstoreContext, props.app_name])
     
     useTitle("Connecting")
 
@@ -57,7 +62,7 @@ export const SplashScreenView = (props) => {
     if (loading) {
         return (
             <div style={{ textAlign: "center", marginTop: "175px" }}>
-                <img src={`${app_icon}`} alt="App Icon" width="100"></img>
+                { app_icon && <img src={`${app_icon}`} alt="App Icon" width="100"></img> }
                 <h2 style={{ marginTop: 16 }}>Connecting...</h2>
                 <Spin size="large" style={{ marginTop: 16 }}></Spin>
             </div>
@@ -65,7 +70,7 @@ export const SplashScreenView = (props) => {
     } else if (errorPresent) {
         return (
             <div style={{ textAlign: "center", marginTop: "175px" }}>
-                <img src={`${app_icon}`} alt="App Icon" width="100"></img>
+                { app_icon && <img src={`${app_icon}`} alt="App Icon" width="100"></img> }
                 <h2>Error: { props.app_name } did not start</h2>
                 <Button type="primary" onClick={ () => { window.location.reload() } }>Retry</Button>
             </div>
@@ -73,7 +78,7 @@ export const SplashScreenView = (props) => {
     } else if (errorPresent) {
         return (
             <div style={{ textAlign: "center", marginTop: "175px" }}>
-                <img src={`${app_icon}`} alt="App Icon" width="100"></img>
+                { app_icon && <img src={`${app_icon}`} alt="App Icon" width="100"></img> }
                 <h2>Error: { props.app_name } did not start</h2>
                 <Button type="primary" onClick={ () => { window.location.reload() } }>Retry</Button>
             </div>
@@ -83,4 +88,4 @@ export const SplashScreenView = (props) => {
         window.location = decoded_url;
     }
 
-}
+})

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Spin, Button } from "antd";
 import axios from "axios";
 import { callWithRetry } from "../utils";
-import { useEnvironment } from '../contexts';
+import { useEnvironment, useWorkspacesAPI } from '../contexts';
 import { withView } from './';
 import { useTitle } from "./view";
 
@@ -14,11 +14,12 @@ export const SplashScreenView = (props) => {
     if(header !== null) header.style.visibility = "hidden";
     if(sidePanel !== null) sidePanel.style.visibility = "hidden";
     const { context } = useEnvironment();
+    const { appstoreContext } = useWorkspacesAPI()
     const [loading, setLoading] = useState(true);
     const [errorPresent, setErrorPresent] = useState(false);
 
     const decoded_url = decodeURIComponent(props.app_url);
-    const app_icon = `${context.dockstore_app_specs_dir_url}/${props.app_name}/icon.png`
+    const app_icon = `${appstoreContext.dockstore_app_specs_dir_url}/${props.app_name}/icon.png`
     
     useTitle("Connecting")
 

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Spin, Button } from "antd";
 import axios from "axios";
 import { callWithRetry } from "../utils";


### PR DESCRIPTION
UI now loads `dockstore_app_specs_dir_url` from Appstore's context endpoint, instead of including it in env.json.

Side note: we should be doing this for all config that only relates to workspaces functionality instead of adding it into the env.json file.
- Although this whole environment config system could use an overhaul (e.g., both Dug and Appstore APIs implement their own context endpoints for fetching application config, and the env.json file is just used for configuring where to look for these APIs).