### PR TITLE
Fix login form error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "/static/frontend",
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
-    "@ant-design/pro-form": "^1.65.0",
+    "@ant-design/pro-form": "^1.74.7",
     "@antv/g2plot": "^2.4.8",
     "@gatsbyjs/reach-router": "^1.3.9",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/views/workspaces/login/login.js
+++ b/src/views/workspaces/login/login.js
@@ -208,7 +208,7 @@ export const WorkspaceLoginView = withAPIReady(({
                     onFinish={ async () => {
 
                     } }
-                    onFieldsChange={ () => setErrors([]) }
+                    onValuesChange={ () => setErrors([]) }
                     form={ form }
                 >
                     {/* <Alert type="error" message="Your session has expired due to prolonged inactivity. Please login to continue." style={{ marginBottom: 16 }} /> */}

--- a/src/views/workspaces/login/signup.js
+++ b/src/views/workspaces/login/signup.js
@@ -186,7 +186,7 @@ export const WorkspaceSignupView = withSocialSignupAllowed(({
                     onFinish={ async () => {
 
                     } }
-                    onFieldsChange={ () => setErrors([]) }
+                    onValuesChange={ () => setErrors([]) }
                     form={ form }
                 >
                     <UsernameInput name="username" { ...formFieldProps } />


### PR DESCRIPTION
Fix to ensure login form error messages (e.g. "password is incorrect") display properly. This only affects development instances; form login is not used in any production deployments.