### PR TITLE
Remove packages with CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 ###################
 # Build environment
 ###################
-FROM node:18.16-alpine AS builder
-RUN apt remove libtiff6 libxml2 libheif1 libldap-2.5-0 libde265-0 libdav1d6
+FROM node:lts-bullseye-slim AS builder
 
 ARG REACT_APP_WORKSPACES_ENABLED=true
 ENV REACT_APP_WORKSPACES_ENABLED=$REACT_APP_WORKSPACES_ENABLED

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN npm run build
 # Production environment
 ########################
 
-FROM nginx:latest
+FROM nginx:1.25.1-alpine-slim
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/build/ /usr/share/nginx/static/
 # RUN mv /usr/share/nginx/static/frontend/index.html /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Build environment
 ###################
 FROM node:18.16-alpine AS builder
-RUN apk del libtiff6* libxml2* libheif* libldap* libde265* libdav* perl-base*
+RUN apt remove libtiff6 libxml2 libheif1 libldap-2.5-0 libde265-0 libdav1d6
 
 ARG REACT_APP_WORKSPACES_ENABLED=true
 ENV REACT_APP_WORKSPACES_ENABLED=$REACT_APP_WORKSPACES_ENABLED


### PR DESCRIPTION
Updating the base image to this slimmer version give the basic Node libraries and most of the same linux ones. Main benefit is its a smaller size and fewer vulnerabilities