### PR TITLE
Update support page to include HEAL-specific documentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,7 @@ REACT_APP_ANALYTICS=''
 REACT_APP_TRANQL_URL='https:\/\/heal-dev.apps.renci.org\/tranql\/'
 # Brand setting. <braini, catalyst, heal, scidas, eduhelx, helx>
 REACT_APP_UI_BRAND_NAME='catalyst'
-# Hide support page sections if necessary. <'community', 'documentation'>. Comma-delimited string, e.g. "community,documentation"
+# Hide support page sections if necessary. <'community', 'documentation', 'heal-support'>. Comma-delimited string, e.g. "community,documentation"
 REACT_APP_HIDDEN_SUPPORT_SECTIONS=''
 # Hide tabs in the result modal/cards. <'overview', 'studies', 'cdes', 'kgs', 'tranql', 'robokop'>. Comma-delimited string, e.g. "tranql,robokop"
 REACT_APP_HIDDEN_RESULT_TABS=''

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -32,7 +32,7 @@ const HEALSupport = () =>
         <Title level={1}>Need Help?</Title>
         <Typography>To report a bug, request technical assistance, submit user feedback, or submit a different request, visit our Help Portal.</Typography>
         <ul>
-            <li><a href="https://renci.atlassian.net/servicedesk/customer/portal/3" target="_blank" rel="noopener noreferrer"><b>Help Portal</b></a></li>
+            <li><a href="http://bit.ly/HEALSemanticSearch_Help" target="_blank" rel="noopener noreferrer"><b>Help Portal</b></a></li>
         </ul>
 
         <Title level={1}>Documentation</Title>

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -27,6 +27,25 @@ const Documentation = () =>
     </ul>
   </Fragment>
 
+const HEALSupport = () =>
+    <Fragment>
+        <Title level={1}>Need Help?</Title>
+        <Typography>To report a bug, request technical assistance, submit user feedback, or submit a different request, visit our Help Portal.</Typography>
+        <ul>
+            <li><a href="https://renci.atlassian.net/servicedesk/customer/portal/3" target="_blank" rel="noopener noreferrer"><b>Help Portal</b></a></li>
+        </ul>
+
+        <Title level={1}>Documentation</Title>
+        <Typography>
+            Our documentation is designed to help guide you through your first steps with HEAL Semantic Search.
+            We encourage you to get started with these introductory materials.
+        </Typography>
+        <ul>
+            <li><b>User Guide</b> (in development)</li>
+            <li><b>FAQs</b> (in development)</li>
+        </ul>
+    </Fragment>
+
 export const SupportView = () => {
   const { context } = useEnvironment()
   useTitle("Support")
@@ -35,6 +54,7 @@ export const SupportView = () => {
     <Fragment>
       {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('community') && <CommunitySupport />}
       {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('documentation') && <Documentation />}
+      {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('heal-support') && <HEALSupport />}
     </Fragment>
   )
 }


### PR DESCRIPTION
This PR updates the Dug Support page to have a `heal-support` section, which can be hidden by adding `heal-support` to the configuration variable `hidden_support_sections`. Note that if this is merged, the Helm charts for all the Dugs will need to be updated, so that HEAL Dug's `hidden_support_sections` is set to `community,documentation` and all the other Dugs are set to `heal-support` to prevent showing all three sections.

This is what the support page should look like for HEAL:
<img width="1079" alt="Screenshot 2023-09-01 at 3 48 39 PM" src="https://github.com/helxplatform/helx-ui/assets/23979/0b5d5206-107b-4e3d-aaef-fd8114e3f0cc">
