### PR TITLE
Use context.meta.title in footer and mobile menu header

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -93,7 +93,7 @@ export const Layout = ({ children }) => {
         {children}
         {context.workspaces_enabled === 'true' && <SidePanel />}
       </Content>
-      <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy; HeLx {new Date().getFullYear()}</Footer>
+      <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy; { context?.meta.title ?? 'HeLx' } {new Date().getFullYear()}</Footer>
     </AntLayout>
   )
 }

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -97,7 +97,7 @@ export const Layout = ({ children }) => {
         context?.brand === 'heal'
         ? <Footer style={{ textAlign: 'center', paddingTop: 0 }}>
           NIH HEAL Semantic Search is powered by Dug, an open source semantic search developed
-          by <a href="https://renci.org">RENCI</a> and <a href="https://www.rti.org/">RTI International</a>
+          by <a href="https://renci.org" target="_blank">RENCI</a> and <a href="https://www.rti.org/" target="_blank">RTI International</a>
         </Footer>
         : <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy;{ context?.meta.title ?? 'HeLx' }{new Date().getFullYear()}</Footer>
       }

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -93,7 +93,15 @@ export const Layout = ({ children }) => {
         {children}
         {context.workspaces_enabled === 'true' && <SidePanel />}
       </Content>
-      <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy; { context?.meta.title ?? 'HeLx' } {new Date().getFullYear()}</Footer>
+      {
+        context?.brand === 'heal'
+        ? <Footer style={{ textAlign: 'center', paddingTop: 0 }}>
+          NIH HEAL Semantic Search is powered by Dug, an open source semantic search developed
+          by <a href="https://renci.org">RENCI</a> and <a href="https://www.rti.org/">RTI International</a>
+        </Footer>
+        : <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy;{ context?.meta.title ?? 'HeLx' }{new Date().getFullYear()}</Footer>
+      }
+      <Footer style={{ textAlign: 'center', paddingTop: 0 }}></Footer>
     </AntLayout>
   )
 }

--- a/src/components/layout/menu/mobile-menu.js
+++ b/src/components/layout/menu/mobile-menu.js
@@ -23,7 +23,11 @@ export const MobileMenu = ({menu}) => {
         <div className="mobile-menu-toggle">
             <Button onClick={() => setVisible(true)}><MenuOutlined /></Button>
             <Drawer
-                title={ context?.meta.title ?? 'HeLx' }
+                title={ 
+                    context?.brand === 'heal' 
+                    ? 'NIH HEAL Semantic Search'
+                    : context?.meta.title ?? 'HeLx'
+                }
                 placement="right"
                 closable={false}
                 onClose={() => setVisible(false)}

--- a/src/components/layout/menu/mobile-menu.js
+++ b/src/components/layout/menu/mobile-menu.js
@@ -23,7 +23,7 @@ export const MobileMenu = ({menu}) => {
         <div className="mobile-menu-toggle">
             <Button onClick={() => setVisible(true)}><MenuOutlined /></Button>
             <Drawer
-                title="HeLx UI"
+                title={ context?.meta.title ?? 'HeLx' }
                 placement="right"
                 closable={false}
                 onClose={() => setVisible(false)}


### PR DESCRIPTION
this PR replaces uses the context value `context.meta.title` in place of "HeLx" in two places: the footer and the mobile menu.

note this approach mimics what's already in place in `view.tsx` for the window title.