### PR TITLE
Remove counts from concept modal and minor lint fixes

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -95,7 +95,7 @@ export const Layout = ({ children }) => {
       {
         context?.brand === 'heal'
         ? <Footer style={{ textAlign: 'center', paddingTop: 0 }}>
-          HEAL Semantic Search is powered by Dug, an open source semantic search developed
+          NIH HEAL Semantic Search is powered by Dug, an open source semantic search developed
           by <a href="https://renci.org" target="_blank" rel="noopener noreferrer">RENCI</a> and <a href="https://www.rti.org/" target="_blank" rel="noopener noreferrer">RTI International</a>
         </Footer>
         : <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy;{ context?.meta.title ?? 'HeLx' }{new Date().getFullYear()}</Footer>

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -96,7 +96,7 @@ export const Layout = ({ children }) => {
       {
         context?.brand === 'heal'
         ? <Footer style={{ textAlign: 'center', paddingTop: 0 }}>
-          NIH HEAL Semantic Search is powered by Dug, an open source semantic search developed
+          HEAL Semantic Search is powered by Dug, an open source semantic search developed
           by <a href="https://renci.org" target="_blank" rel="noreferrer">RENCI</a> and <a href="https://www.rti.org/" target="_blank" rel="noreferrer">RTI International</a>
         </Footer>
         : <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy;{ context?.meta.title ?? 'HeLx' }{new Date().getFullYear()}</Footer>

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -97,7 +97,7 @@ export const Layout = ({ children }) => {
         context?.brand === 'heal'
         ? <Footer style={{ textAlign: 'center', paddingTop: 0 }}>
           NIH HEAL Semantic Search is powered by Dug, an open source semantic search developed
-          by <a href="https://renci.org" target="_blank">RENCI</a> and <a href="https://www.rti.org/" target="_blank">RTI International</a>
+          by <a href="https://renci.org" target="_blank" rel="noreferrer">RENCI</a> and <a href="https://www.rti.org/" target="_blank" rel="noreferrer">RTI International</a>
         </Footer>
         : <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy;{ context?.meta.title ?? 'HeLx' }{new Date().getFullYear()}</Footer>
       }

--- a/src/components/layout/menu/mobile-menu.js
+++ b/src/components/layout/menu/mobile-menu.js
@@ -23,11 +23,7 @@ export const MobileMenu = ({menu}) => {
         <div className="mobile-menu-toggle">
             <Button onClick={() => setVisible(true)}><MenuOutlined /></Button>
             <Drawer
-                title={ 
-                    context?.brand === 'heal' 
-                    ? 'NIH HEAL Semantic Search'
-                    : context?.meta.title ?? 'HeLx'
-                }
+                title={ context?.meta.title ?? 'HeLx' }
                 placement="right"
                 closable={false}
                 onClose={() => setVisible(false)}

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -61,6 +61,6 @@ class Modal extends Component {
             </Background>
     )
   }
-};
+}
 
 export {Modal};

--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -88,12 +88,12 @@ export const ConceptModalBody = ({ result }) => {
 
   const studyTitle = (
     <div style={{ display: "inline" }}>
-      Studies { studies ? `(${ Object.keys(studies).length })` : <BouncingDots /> }
+      Studies
     </div>
   )
   const cdeTitle = (
     <div style={{ display: "inline" }}>
-      CDEs { !cdesLoading ? `(${ Object.keys(cdes ?? []).length })` : <BouncingDots />  }
+      CDEs
     </div>
   )
 


### PR DESCRIPTION
This PR removes the counts from the tabs in the concept modal, as brought up in https://renci.atlassian.net/browse/DUG-348. As far as I can tell, the code being deleted here is identical to the code in src/components/search/concept-card/concept-card.js, so I have no idea why the counts are off, but this should hide the oddness until we can properly fix and close https://renci.atlassian.net/browse/DUG-348.

I ran into some linting issues and had to fix them to try this out:
1. `npm run lint` required adding `rel=noreferrer` for the two `target='_blank'` links added in PR #270, with a link to
https://mathiasbynens.github.io/rel-noopener/#recommendations by way of an explanation. I've done that, but I wonder if `target='_blank'` is a bad idea for some reason?
2. Removed one unnecessary semicolon.

Supercedes PR #267