### PR TITLE
Adds updated HEAL support links

### DIFF
--- a/src/contexts/analytics-context/events/support-events.js
+++ b/src/contexts/analytics-context/events/support-events.js
@@ -4,3 +4,17 @@ export function helpPortalOpened() {
         action: "support_help_portal_open"
     });
 }
+
+export function userGuideOpened() {
+    this.analytics.trackEvent({
+        category: "ui_interaction",
+        action: "support_user_guide_open"
+    });
+}
+
+export function faqsOpened() {
+    this.analytics.trackEvent({
+        category: "ui_interaction",
+        action: "support_faqs_open"
+    });
+}

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -2,6 +2,7 @@ import { Fragment, useEffect } from 'react'
 import { Typography } from 'antd'
 import { useAnalytics, useEnvironment } from '../contexts'
 import { useTitle } from './'
+import {faqsOpened, userGuideOpened} from "../contexts/analytics-context/events/support-events";
 
 const { Title } = Typography
 
@@ -57,9 +58,30 @@ const HEALSupport = () => {
               We encourage you to get started with these introductory materials.
           </Typography>
           <ul>
-              {/* ADD analytics here when complete. */}
-              <li><b>User Guide</b> (in development)</li>
-              <li><b>FAQs</b> (in development)</li>
+              <li>
+                  <a
+                      href="https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={ () => {
+                          analyticsEvents.userGuideOpened()
+                      } }
+                  >
+                      <b>User Guide</b>
+                  </a>
+              </li>
+              <li>
+                  <a
+                      href="https://docs.google.com/document/d/1njtRJbdHePRE-1kYtmyli-NqVuwU9bdqZ-42RNQGpBI/edit"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={ () => {
+                          analyticsEvents.faqsOpened()
+                      } }
+                  >
+                    <b>FAQs</b>
+                  </a>
+              </li>
           </ul>
         </div>
     </Fragment>


### PR DESCRIPTION
This PR updates the links for the user guide and FAQ in https://renci.atlassian.net/browse/DUG-363 and (tries to) add analytics events for both of these.

Links added:
- User Guide: https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1
- FAQs: https://docs.google.com/document/d/1njtRJbdHePRE-1kYtmyli-NqVuwU9bdqZ-42RNQGpBI/edit

Closes https://renci.atlassian.net/browse/DUG-363