### PR TITLE
Alter readiness check to use the is_ready API endpoint 

### DIFF
--- a/src/contexts/instance-context.js
+++ b/src/contexts/instance-context.js
@@ -30,7 +30,7 @@ export const InstanceProvider = ({ children }) => {
         // let ready = false;
         const decoded_url = decodeURIComponent(app_url);
         const executePoll = async () => {
-            const isAppReady = await api.getAppReady(app_url);
+            const isAppReady = await api.getAppReady(decoded_url);
             if (isAppReady) {
                 let newActivity = {
                     'sid': sid,

--- a/src/contexts/instance-context.js
+++ b/src/contexts/instance-context.js
@@ -27,10 +27,13 @@ export const InstanceProvider = ({ children }) => {
     // Clear its timeout when the instance is deleted by user.
 
     const pollingInstance = (app_id, sid, app_url, app_name) => {
-        // let ready = false;
         const decoded_url = decodeURIComponent(app_url);
         const executePoll = async () => {
-            const isAppReady = await api.getAppReady(decoded_url);
+            let isAppReady = false;
+
+            try {
+               isAppReady = await api.getAppReady(decoded_url);
+            } catch(e) {} // just absorb the exception, the default false is correct here
             if (isAppReady) {
                 let newActivity = {
                     'sid': sid,

--- a/src/contexts/workspaces-context/api.ts
+++ b/src/contexts/workspaces-context/api.ts
@@ -317,12 +317,6 @@ export class WorkspacesAPI implements IWorkspacesAPI {
     }
 
     @APIRequest()
-    async getAppInstanceIsReady(sid: string, fetchOptions: AxiosRequestConfig={}): Promise<AppInstanceIsReadyResponse> {
-        const res = await this.axios.get<AppInstanceIsReadyResponse>(`/instances/${ sid }/is_ready/`);
-        return res.data;
-    }
-
-    @APIRequest()
     async updateAppInstance(
         sid: string,
         workspace: string,
@@ -362,19 +356,22 @@ export class WorkspacesAPI implements IWorkspacesAPI {
     }
 
     @APIRequest()
-    async getAppReady(appUrl: string, fetchOptions: AxiosRequestConfig={}): Promise<boolean> {
+    async getAppReady(decodedURL: string, fetchOptions: AxiosRequestConfig={}): Promise<boolean> {
+        let parts = decodedURL.split('/');
+        let sid = (parts.length >= 2)?parts[parts.length - 2]:"";
+
+        if(sid.length == 0) return false;
         try {
-            // appUrl is a full URL, not a relative path.
-            const res = await this.axios.get(appUrl, {
-                ...fetchOptions,
-                baseURL: undefined
-            })
-            return res.status === 200
+            const res = await this.axios.get<AppInstanceIsReadyResponse>(`/instances/${ sid }/is_ready/`, {
+                ...fetchOptions
+            });
+            if(res.data) return res.data.is_ready;
+            return false;
         } catch (e: any) {
+            console.log("error getting ready status",e)
             return false
         }
     }
-
 }
 
 /**

--- a/src/contexts/workspaces-context/api.ts
+++ b/src/contexts/workspaces-context/api.ts
@@ -361,16 +361,11 @@ export class WorkspacesAPI implements IWorkspacesAPI {
         let sid = (parts.length >= 2)?parts[parts.length - 2]:"";
 
         if(sid.length == 0) return false;
-        try {
-            const res = await this.axios.get<AppInstanceIsReadyResponse>(`/instances/${ sid }/is_ready/`, {
-                ...fetchOptions
-            });
-            if(res.data) return res.data.is_ready;
-            return false;
-        } catch (e: any) {
-            console.log("error getting ready status",e)
-            return false
-        }
+        const res = await this.axios.get<AppInstanceIsReadyResponse>(`/instances/${ sid }/is_ready/`, {
+            ...fetchOptions
+        });
+        if(res.data) return res.data.is_ready;
+        return false;
     }
 }
 

--- a/src/contexts/workspaces-context/api.ts
+++ b/src/contexts/workspaces-context/api.ts
@@ -317,6 +317,12 @@ export class WorkspacesAPI implements IWorkspacesAPI {
     }
 
     @APIRequest()
+    async getAppInstanceIsReady(sid: string, fetchOptions: AxiosRequestConfig={}): Promise<AppInstanceIsReadyResponse> {
+        const res = await this.axios.get<AppInstanceIsReadyResponse>(`/instances/${ sid }/is_ready/`);
+        return res.data;
+    }
+
+    @APIRequest()
     async updateAppInstance(
         sid: string,
         workspace: string,

--- a/src/contexts/workspaces-context/api.types.ts
+++ b/src/contexts/workspaces-context/api.types.ts
@@ -139,6 +139,7 @@ export interface AppInstance {
     cpus: number
     gpus: number
     memory: string
+    is_ready: boolean
     url: string
     status: string
 }
@@ -146,6 +147,10 @@ export interface AvailableAppsResponse {
     [appName: string]: AvailableApp
 }
 export type AppInstancesResponse = AppInstance[]
+export interface AppInstanceIsReadyResponse {
+    is_ready: boolean
+}
+
 export interface UpdateAppInstanceResponse {
     status: "success" | "error"
     message: string

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -32,12 +32,9 @@ export const SplashScreenView = withWorkspaceAuthentication((props) => {
         let shouldCancel = false;
         (async () => {
             try {
-                let parts = decoded_url.split('/');
-                let sid = (parts.length >= 2)?parts[parts.length - 2]:"";
-
                 await callWithRetry(async () => { 
-                    const res = await api.getAppInstanceIsReady(sid);
-                    if (res.is_ready == true && shouldCancel === false) {
+                    const is_ready = await api.getAppReady(decoded_url);
+                    if (is_ready && shouldCancel === false) {
                         setLoading(false)
                     } else {
                         throw new Error("app not ready")

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -33,8 +33,8 @@ export const SplashScreenView = withWorkspaceAuthentication((props) => {
         (async () => {
             try {
                 await callWithRetry(async () => { 
-                    const is_ready = await api.getAppReady(decoded_url);
-                    if (is_ready && shouldCancel === false) {
+                    const isReady = await api.getAppReady(decoded_url);
+                    if (isReady && shouldCancel === false) {
                         setLoading(false)
                     } else {
                         throw new Error("app not ready")

--- a/src/views/splash-screen.js
+++ b/src/views/splash-screen.js
@@ -15,7 +15,7 @@ export const SplashScreenView = withWorkspaceAuthentication((props) => {
     if(header !== null) header.style.visibility = "hidden";
     if(sidePanel !== null) sidePanel.style.visibility = "hidden";
     const { context } = useEnvironment();
-    const { appstoreContext } = useWorkspacesAPI()
+    const { api, appstoreContext } = useWorkspacesAPI()
     const [loading, setLoading] = useState(true);
     const [errorPresent, setErrorPresent] = useState(false);
 
@@ -32,15 +32,18 @@ export const SplashScreenView = withWorkspaceAuthentication((props) => {
         let shouldCancel = false;
         (async () => {
             try {
+                let parts = decoded_url.split('/');
+                let sid = (parts.length >= 2)?parts[parts.length - 2]:"";
+
                 await callWithRetry(async () => { 
-                    const res = await axios.get(decoded_url) 
-                    if (res.status === 200 && shouldCancel === false) {
+                    const res = await api.getAppInstanceIsReady(sid);
+                    if (res.is_ready == true && shouldCancel === false) {
                         setLoading(false)
                     } else {
-                        throw new Error("Could not ensure readiness of app URL")
+                        throw new Error("app not ready")
                     }
                 }, {
-                    failedCallback: () => {
+                    failedCallback: (e) => {
                         return shouldCancel
                     },
                     timeout: 240000,


### PR DESCRIPTION
Add support for checking the readiness of an App in a different way.  Previously, the UI (splash screen) would try to 
connect the main interface of the App.  With this change, it instead checks against a new API endpoint. `/v1/instances/{sid}/is_ready/`.  The result will be false until the pod underlying the App passes its readiness probe.