### PR TITLE
Fix bug in activity monitor for removed apps

### DIFF
--- a/src/components/side-panel/side-panel.js
+++ b/src/components/side-panel/side-panel.js
@@ -11,9 +11,15 @@ import './side-panel.css';
 const { Panel } = Collapse
 
 const ActivityLog = ({ events, setShowEventInfo }) => {
-    const [collapsed, setCollapsed] = useState(true)
+    const { appSpecs } = useActivity()
 
-    const [latestActivity, ...otherActivities] = useMemo(() => events, [events])
+    const [collapsed, setCollapsed] = useState(true)
+    const cleanedEvents = useMemo(() => events.filter((event) => {
+        // If an event exists for an app that has been removed from
+        // the available apps list, then we need to remove that event.
+        return appSpecs.hasOwnProperty(event.data.appId)
+    }), [events, appSpecs])
+    const [latestActivity, ...otherActivities] = useMemo(() => cleanedEvents, [cleanedEvents])
 
     return (
         <Collapse


### PR DESCRIPTION
A bug could occur where if a user had activity monitor events for an app that has since been removed from Appstore, it would cause an error and give a blank screen. This previously wasn't a concern but now that the activity monitor is persistent this needs to be considered. This PR fixes this bug.