### PR TITLE
FEAT: Adding a setting to configure the landing space for the website

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,8 @@
 REACT_APP_WORKSPACES_ENABLED=false
 # Enable when working with Dug
 REACT_APP_SEMANTIC_SEARCH_ENABLED='true'
+# Identify landing spacein the UI:
+REACT_APP_DEFAULT_SPACE='workspaces'
 # Points the app to the Dug API
 REACT_APP_HELX_SEARCH_URL='https:\/\/heal-dev.apps.renci.org\/search-api'
 # Only necessary if working with analytics specifically.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ directly rather than regenerating it.
 See `.env.example` for the most up to date variables and appropriate default values.
 - `REACT_APP_REACT_APP_WORKSPACES_ENABLED`: enables workspaces functionality (requires Appstore)
 - `REACT_APP_SEMANTIC_SEARCH_ENABLED`: enables semantic search functionality
+- `REACT_APP_DEFAULT_SPACE`: identify default landing space: workspaces | search | support
 - `REACT_APP_HELX_SEARCH_URL`: points the UI to the Dug semantic search API
 - `REACT_APP_UI_BRAND_NAME`: heal | braini | catalyst | scidas | eduhelx | helx
 - `REACT_APP_TRANQL_ENABLED`: enables the TranQL visualization pane in search results

--- a/bin/output.json
+++ b/bin/output.json
@@ -1,1 +1,1 @@
-{ "brand": "", "color_scheme": { "primary": "#8a5a91", "secondary": "#505057" }, "search_url": "", "search_enabled": "true", "workspaces_enabled": "true" }
+{ "brand": "", "color_scheme": { "primary": "#8a5a91", "secondary": "#505057" }, "search_url": "", "search_enabled": "true", "workspaces_enabled": "true", "default_space": "workspaces" }

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -8,6 +8,7 @@ fi
 
 workspaces_enabled="${REACT_APP_WORKSPACES_ENABLED:-true}"
 search_enabled="${REACT_APP_SEMANTIC_SEARCH_ENABLED:-true}"
+default_space="${REACT_APP_DEFAULT_SPACE:-workspaces}"
 search_url="${REACT_APP_HELX_SEARCH_URL}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
 tranql_url="${REACT_APP_TRANQL_URL:-\/tranql}"
@@ -28,6 +29,7 @@ template='{
     "search_url": "%SEARCH_URL%",
     "search_enabled": "%SEARCH_ENABLED%",
     "workspaces_enabled": "%WORKSPACES_ENABLED%",
+    "default_space": "%DEFAULT_SPACE%",
     "tranql_url": "%TRANQL_URL%",
     "analytics": {
       "enabled": %ANALYTICS_ENABLED%,
@@ -47,6 +49,7 @@ template='{
 echo "$template" | sed \
   -e "s/%WORKSPACES_ENABLED%/$workspaces_enabled/" \
   -e "s/%SEARCH_ENABLED%/$search_enabled/" \
+  -e "s/%DEFAULT_SPACE%/$default_space/" \
   -e "s/%SEARCH_URL%/$search_url/" \
   -e "s/%BRAND%/$brand_name/" \
   -e "s/%HIDDEN_SUPPORT_SECTIONS%/$hidden_support_sections/" \

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -8,7 +8,7 @@ fi
 
 workspaces_enabled="${REACT_APP_WORKSPACES_ENABLED:-true}"
 search_enabled="${REACT_APP_SEMANTIC_SEARCH_ENABLED:-true}"
-default_space="${REACT_APP_DEFAULT_SPACE:-workspaces}"
+default_space="${REACT_APP_DEFAULT_SPACE:-search}"
 search_url="${REACT_APP_HELX_SEARCH_URL}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
 tranql_url="${REACT_APP_TRANQL_URL:-\/tranql}"

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -43,18 +43,25 @@ export const EnvironmentProvider = ({ children }) => {
   // If workspace module is enabled, all relevant paths will be added. (/workspaces/active, workspace/available, ...)
   // Note: `parent` property refers to another equivalent or encapsulating route that occupies an entry in the site's header.
   // It's important to include this if applicable so that the header entry stays active, e.g. on subroutes of workspaces.
-  const generateRoutes = (searchEnabled, workspaceEnabled) => {
+  const generateRoutes = (searchEnabled, workspaceEnabled, defaultSpace) => {
     const baseRoutes = [];
-    if (searchEnabled === 'true') {
-      // route homepage to search if search is enabled
+    
+    // First push path for the landing space depending on what is defined in defaultSpace and enabled.
+    if (defaultSpace=='workspaces' && workspaceEnabled=='true') {
+      baseRoutes.push({ path: '/', parent: '/workspaces', text: '', Component: AvailableView })  
+    }
+    else if(defaultSpace=='search' && searchEnabled=='true') {
       baseRoutes.push({ path: '/', parent: '/search', text: '', Component: SearchView })
+    }
+    else{
+      baseRoutes.push({ path: '/', parent: '/support', text: '', Component: SupportView })
+    }
+
+    // Push space related paths
+    if (searchEnabled == 'true') {
       baseRoutes.push({ path: '/search', text: 'Search', Component: SearchView })
     }
     if (workspaceEnabled === 'true') {
-      // route homepage to apps page if search is disabled
-      if (searchEnabled === 'false') {
-        baseRoutes.push({ path: '/', parent: '/workspaces', text: '', Component: AvailableView })
-      }
       baseRoutes.push({ path: '/workspaces', text: 'Workspaces', Component: AvailableView })
       baseRoutes.push({ path: '/workspaces/login', parent: '/workspaces', text: '', Component: WorkspaceLoginView })
       baseRoutes.push({ path: '/workspaces/login/success', parent: '/workspaces', text: '', Component: LoginSuccessRedirectView })
@@ -62,10 +69,6 @@ export const EnvironmentProvider = ({ children }) => {
       baseRoutes.push({ path: '/workspaces/available', parent: '/workspaces', text: '', Component: AvailableView })
       baseRoutes.push({ path: '/workspaces/active', parent: '/workspaces', text: '', Component: ActiveView })
       baseRoutes.push({ path: '/connect/:app_name/:app_url', parent: '/workspaces', text: '', Component: SplashScreenView })
-    }
-    if (searchEnabled === 'false' && workspaceEnabled === 'false') {
-      // route homepage to support page if both search and workspaces are disabled
-      baseRoutes.push({ path: '/', parent: '/support', text: '', Component: SupportView })
     }
     baseRoutes.push({ path: '/support', text: 'Support', Component: SupportView })
     return baseRoutes;
@@ -106,7 +109,7 @@ export const EnvironmentProvider = ({ children }) => {
   // If workspace is enabled, all routes should have a '/helx' basePath as the ui is embedded in the appstore
   useEffect(() => {
     if (Object.keys(context).length !== 0) {
-      const routes = generateRoutes(context.search_enabled, context.workspaces_enabled);
+      const routes = generateRoutes(context.search_enabled, context.workspaces_enabled, context.default_space);
       setAvailableRoutes(routes);
       if (context.workspaces_enabled === 'true') {
         setBasePath('/helx/');


### PR DESCRIPTION
The setting default_space (through env. variable REACT_APP_DEFAULT_SPACE) is added to make either workspaces/search/support to be the landing space to the deployed website. 