### PR TITLE
Fix spacing in copyright footer

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -98,7 +98,7 @@ export const Layout = ({ children }) => {
           NIH HEAL Semantic Search is powered by Dug, an open source semantic search developed
           by <a href="https://renci.org" target="_blank" rel="noopener noreferrer">RENCI</a> and <a href="https://www.rti.org/" target="_blank" rel="noopener noreferrer">RTI International</a>
         </Footer>
-        : <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy;{ context?.meta.title ?? 'HeLx' }{new Date().getFullYear()}</Footer>
+        : <Footer style={{ textAlign: 'center', paddingTop: 0 }}>&copy; { context?.meta.title ?? 'HeLx' } {new Date().getFullYear()}</Footer>
       }
     </AntLayout>
   )


### PR DESCRIPTION
I think when the custom HEAL banner was added the spaces between the copyright symbol, website name, and year were removed. This adds them back.