### PR TITLE
Add several "branding" options for configurations. 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,3 +26,10 @@ REACT_APP_APPSTORE_ASSET_BRANCH=master
 REACT_APP_LOGIN_TITLE='HeLX Workspaces'
 # Set text for Login page. 
 REACT_APP_LOGIN_TEXT=''
+# Support pages vlue:
+# Link to a help portal, sample is for HEAL as of 01/25/2024
+REACT_APP_SUPPORT_HELP_PORTAL_URL='http:\/\/bit.ly\/HEALSemanticSearch_Help'
+# Link to a user guide, sample is for HEAL as of 01/25/2024
+REACT_APP_SUPPORT_USER_GUIDE_URL='https:\/\/docs.google.com\/document\/d\/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q\/edit?pli=1'
+# Link to a Faqs page, sample is for HEAL as of 01/25/2024
+REACT_APP_SUPPORT_FAQS_URL='https:\/\/docs.google.com\/document\/d\/1njtRJbdHePRE-1kYtmyli-NqVuwU9bdqZ-42RNQGpBI\/edit'

--- a/.env.sample
+++ b/.env.sample
@@ -24,8 +24,6 @@ REACT_APP_DOCKSTORE_BRANCH=master
 REACT_APP_APPSTORE_ASSET_BRANCH=master
 # Set heading for the login page. If this is not supplied, will use website title to create one.
 REACT_APP_LOGIN_TITLE='HeLX Workspaces'
-# Set text for Login page. 
-REACT_APP_LOGIN_TEXT=''
 # Support pages vlue:
 # Link to a help portal, sample is for HEAL as of 01/25/2024
 REACT_APP_SUPPORT_HELP_PORTAL_URL='http:\/\/bit.ly\/HEALSemanticSearch_Help'

--- a/.env.sample
+++ b/.env.sample
@@ -14,8 +14,6 @@ REACT_APP_ANALYTICS=''
 REACT_APP_TRANQL_URL='https:\/\/heal-dev.apps.renci.org\/tranql\/'
 # Brand setting. <braini, catalyst, heal, scidas, eduhelx, helx>
 REACT_APP_UI_BRAND_NAME='catalyst'
-# Hide support page sections if necessary. <'community', 'documentation', 'heal-support'>. Comma-delimited string, e.g. "community,documentation"
-REACT_APP_HIDDEN_SUPPORT_SECTIONS=''
 # Hide tabs in the result modal/cards. <'overview', 'studies', 'cdes', 'kgs', 'tranql', 'robokop'>. Comma-delimited string, e.g. "tranql,robokop"
 REACT_APP_HIDDEN_RESULT_TABS=''
 # Some static assets such as app logo are loaded externally from the dockstore repository (helx-apps).

--- a/.env.sample
+++ b/.env.sample
@@ -22,3 +22,7 @@ REACT_APP_HIDDEN_RESULT_TABS=''
 REACT_APP_DOCKSTORE_BRANCH=master
 # Some static assets such as brand logo are loaded externally from the Appstore repository.
 REACT_APP_APPSTORE_ASSET_BRANCH=master
+# Set heading for the login page. If this is not supplied, will use website title to create one.
+REACT_APP_LOGIN_TITLE='HeLX Workspaces'
+# Set text for Login page. 
+REACT_APP_LOGIN_TEXT=''

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ See `.env.example` for the most up to date variables and appropriate default val
 - `REACT_APP_UI_BRAND_NAME`: heal | braini | catalyst | scidas | eduhelx | helx
 - `REACT_APP_TRANQL_ENABLED`: enables the TranQL visualization pane in search results
 - `REACT_APP_TRANQL_URL`: points the UI to the TranQL deployment
-- `REACT_APP_HIDDEN_SUPPORT_SECTIONS`: hides support page sections, if necessary
 - `REACT_APP_DOCKSTORE_BRANCH`: used to point the UI to an alternative Dockstore branch
 - `REACT_APP_APPSTORE_ASSET_BRANCH`: used to point the UI to an alternative Appstore branch to load static assets
 

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -21,7 +21,8 @@ analytics_platform="${REACT_APP_ANALYTICS_PLATFORM}"
 analytics_token="${REACT_APP_ANALYTICS_TOKEN}"
 meta_title="${META_TITLE:-HeLx UI}"
 meta_description="${META_DESCRIPTION:-HeLx UI}"
-
+login_title="${REACT_APP_LOGIN_TITLE}"
+login_text="${REACT_APP_LOGIN_TEXT}"
 
 template='{
     "brand": "%BRAND%",
@@ -43,7 +44,9 @@ template='{
     "meta": {
       "title": "%META_TITLE%",
       "description": "%META_DESCRIPTION%"
-    }
+    },
+    "login_title": "%LOGIN_TITLE%",
+    "login_text": "%LOGIN_TEXT%"
 }'
 
 echo "$template" | sed \
@@ -62,4 +65,6 @@ echo "$template" | sed \
   -e "s/%ANALYTICS_TOKEN%/$analytics_token/" \
   -e "s/%META_TITLE%/$meta_title/" \
   -e "s/%META_DESCRIPTION%/$meta_description/" \
+  -e "s/%LOGIN_TITLE%/$login_title/" \
+  -e "s/%LOGIN_TEXT%/$login_text/" \
   > $1

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -23,6 +23,9 @@ meta_title="${META_TITLE:-HeLx UI}"
 meta_description="${META_DESCRIPTION:-HeLx UI}"
 login_title="${REACT_APP_LOGIN_TITLE}"
 login_text="${REACT_APP_LOGIN_TEXT}"
+support_help_url="${REACT_APP_SUPPORT_HELP_PORTAL_URL}"
+support_user_guide_url="${REACT_APP_SUPPORT_USER_GUIDE_URL}"
+support_faqs_url="${REACT_APP_SUPPORT_FAQS_URL}"
 
 template='{
     "brand": "%BRAND%",
@@ -46,7 +49,12 @@ template='{
       "description": "%META_DESCRIPTION%"
     },
     "login_title": "%LOGIN_TITLE%",
-    "login_text": "%LOGIN_TEXT%"
+    "login_text": "%LOGIN_TEXT%",
+    "support": {
+      "help_portal_url": "%SUPPORT_HELP_PORTAL_URL%",
+      "user_guide_url": "%SUPPORT_USER_GUIDE_URL%",
+      "faqs_url": "%SUPPORT_FAQS_URL%"
+    }
 }'
 
 echo "$template" | sed \
@@ -67,4 +75,7 @@ echo "$template" | sed \
   -e "s/%META_DESCRIPTION%/$meta_description/" \
   -e "s/%LOGIN_TITLE%/$login_title/" \
   -e "s/%LOGIN_TEXT%/$login_text/" \
+  -e "s/%SUPPORT_HELP_PORTAL_URL%/$support_help_url/" \
+  -e "s/%SUPPORT_USER_GUIDE_URL%/$support_user_guide_url/" \
+  -e "s/%SUPPORT_FAQS_URL%/$support_faqs_url/" \
   > $1

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -12,7 +12,6 @@ default_space="${REACT_APP_DEFAULT_SPACE:-search}"
 search_url="${REACT_APP_HELX_SEARCH_URL}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
 tranql_url="${REACT_APP_TRANQL_URL:-\/tranql}"
-hidden_support_sections="${REACT_APP_HIDDEN_SUPPORT_SECTIONS}"
 hidden_result_tabs="${REACT_APP_HIDDEN_RESULT_TABS}"
 deployment_namespace="${REACT_APP_DEPLOYMENT_NAMESPACE}"
 appstore_asset_branch="${REACT_APP_APPSTORE_ASSET_BRANCH}"
@@ -39,7 +38,6 @@ template='{
       "platform": "%ANALYTICS_PLATFORM%",
       "token": "%ANALYTICS_TOKEN%"
     },
-    "hidden_support_sections": "%HIDDEN_SUPPORT_SECTIONS%",
     "hidden_result_tabs": "%HIDDEN_RESULT_TABS%",
     "deployment_namespace": "%DEPLOYMENT_NAMESPACE%",
     "appstore_asset_branch": "%APPSTORE_ASSET_BRANCH%",
@@ -61,7 +59,6 @@ echo "$template" | sed \
   -e "s/%DEFAULT_SPACE%/$default_space/" \
   -e "s/%SEARCH_URL%/$search_url/" \
   -e "s/%BRAND%/$brand_name/" \
-  -e "s/%HIDDEN_SUPPORT_SECTIONS%/$hidden_support_sections/" \
   -e "s/%HIDDEN_RESULT_TABS%/$hidden_result_tabs/" \
   -e "s/%TRANQL_URL%/$tranql_url/" \
   -e "s/%DEPLOYMENT_NAMESPACE%/$deployment_namespace/" \

--- a/bin/populate_env
+++ b/bin/populate_env
@@ -22,7 +22,6 @@ analytics_token="${REACT_APP_ANALYTICS_TOKEN}"
 meta_title="${META_TITLE:-HeLx UI}"
 meta_description="${META_DESCRIPTION:-HeLx UI}"
 login_title="${REACT_APP_LOGIN_TITLE}"
-login_text="${REACT_APP_LOGIN_TEXT}"
 support_help_url="${REACT_APP_SUPPORT_HELP_PORTAL_URL}"
 support_user_guide_url="${REACT_APP_SUPPORT_USER_GUIDE_URL}"
 support_faqs_url="${REACT_APP_SUPPORT_FAQS_URL}"
@@ -49,7 +48,6 @@ template='{
       "description": "%META_DESCRIPTION%"
     },
     "login_title": "%LOGIN_TITLE%",
-    "login_text": "%LOGIN_TEXT%",
     "support": {
       "help_portal_url": "%SUPPORT_HELP_PORTAL_URL%",
       "user_guide_url": "%SUPPORT_USER_GUIDE_URL%",
@@ -74,7 +72,6 @@ echo "$template" | sed \
   -e "s/%META_TITLE%/$meta_title/" \
   -e "s/%META_DESCRIPTION%/$meta_description/" \
   -e "s/%LOGIN_TITLE%/$login_title/" \
-  -e "s/%LOGIN_TEXT%/$login_text/" \
   -e "s/%SUPPORT_HELP_PORTAL_URL%/$support_help_url/" \
   -e "s/%SUPPORT_USER_GUIDE_URL%/$support_user_guide_url/" \
   -e "s/%SUPPORT_FAQS_URL%/$support_faqs_url/" \

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -87,29 +87,51 @@ export const EnvironmentProvider = ({ children }) => {
       if (!context.appstore_asset_branch) context.appstore_asset_branch = "master"
       if (!context.brand) context.brand = "helx"
       /** Hardcoded for now, if you want custom login text for a brand add it as a case here. */
-      switch (context.brand) {
-        case "eduhelx":
-          context.login_text = (
-            <Fragment>
-              <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale. 
-              EduHeLx, which is a derivative of HeLx, is designed for educational purposes.
-              HeLx/EduHeLx empower researchers, students and educators to leverage advanced analytical tools without installation or other infrastructure concerns, which has broad reaching benefits and can be applied in many domains.
-              <br />&nbsp;<br />
-              The HeLx and EduHeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
-            </Fragment>
-          )
-          break
-        default:
-          context.login_text = (
-            <Fragment>
-              <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale.
-              Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits and can be applied in many domains.
-              <br />&nbsp;<br />
-              The HeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
-            </Fragment>
-          )
-          break
+
+      if (!context.login_title) {
+        context.login_title = context.meta.title ? ([context.meta.title, "Workspaces"].join(" ")) : ("HeLx Workspaces")
       }
+
+      if (!context.login_text) {
+        context.login_text = (
+          <Fragment>
+          <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale. 
+          HeLx empowers researchers, students and educators to leverage advanced analytical tools without installation or other infrastructure concerns, which has broad reaching benefits and can be applied in many domains.
+          <br />&nbsp;<br />
+          The HeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
+          </Fragment>
+        )
+      }
+      else {
+        context.login_text = (
+          <Fragment>
+            { context.login_text }
+          </Fragment>
+        )
+      }
+      // switch (context.brand) {
+      //   case "eduhelx":
+      //     context.login_text = (
+      //       <Fragment>
+      //         <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale. 
+      //         EduHeLx, which is a derivative of HeLx, is designed for educational purposes.
+      //         HeLx/EduHeLx empower researchers, students and educators to leverage advanced analytical tools without installation or other infrastructure concerns, which has broad reaching benefits and can be applied in many domains.
+      //         <br />&nbsp;<br />
+      //         The HeLx and EduHeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
+      //       </Fragment>
+      //     )
+      //     break
+      //   default:
+      //     context.login_text = (
+      //       <Fragment>
+      //         <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale.
+      //         Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits and can be applied in many domains.
+      //         <br />&nbsp;<br />
+      //         The HeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
+      //       </Fragment>
+      //     )
+      //     break
+      // }
 
       // split the comma-separated string which tells ui the support section to hide
       // also trim leading/trailing spaces to allow spaces between commas

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -103,11 +103,23 @@ export const EnvironmentProvider = ({ children }) => {
         )
       }
       else {
-        context.login_text = (
-          <Fragment>
-            { context.login_text }
-          </Fragment>
-        )
+        context.login_text = (<Fragment>Testing out read</Fragment>)
+        fetch('https://raw.githubusercontent.com/helxplatform/appstore/test-hs/appstore/core/static/html/test-read.html')
+        .then(response => {
+          if (!response.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return response.text();
+        })
+        .then(text => {
+          console.log('File contents:', text);
+          context.login_text = ( <Fragment>
+            <div dangerouslySetInnerHTML={{ __html: text }} />
+            </Fragment> )
+        })
+        .catch(error => {
+          console.error('There was a problem with the fetch operation:', error);
+        });
       }
       // switch (context.brand) {
       //   case "eduhelx":

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -120,9 +120,8 @@ export const EnvironmentProvider = ({ children }) => {
       }
       getLoginDesc();
 
-      // split the comma-separated string which tells ui the support section to hide
+      // split the comma-separated string which tells ui which result tabs to hide
       // also trim leading/trailing spaces to allow spaces between commas
-      context.hidden_support_sections = context.hidden_support_sections.split(',').map((section) => section.trim())
       context.hidden_result_tabs = context.hidden_result_tabs.split(',').map((tab) => tab.trim())
 
       // Make sure the tranql_url ends with a slash. If it doesn't, it will redirect, which breaks the iframe for some reason. 

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -102,14 +102,12 @@ export const EnvironmentProvider = ({ children }) => {
       );
 
       const getLoginDesc = async () => {
-        console.log(`${relativeHost}/static/frontend/brand_desc.html`)
         try{
           let response = await fetch(`${relativeHost}/static/frontend/brand_desc.html`)
           if (!response.ok) {
             context.login_text = default_login_text
           }
           const htmlContent = await response.text();
-          console.log("*** GOT THE TEXT: ", htmlContent);
           context.login_text = ( 
             <Fragment>
             <div dangerouslySetInnerHTML={{ __html: htmlContent }} />

--- a/src/contexts/environment-context.js
+++ b/src/contexts/environment-context.js
@@ -91,59 +91,36 @@ export const EnvironmentProvider = ({ children }) => {
       if (!context.login_title) {
         context.login_title = context.meta.title ? ([context.meta.title, "Workspaces"].join(" ")) : ("HeLx Workspaces")
       }
+      
+      const default_login_text = (
+        <Fragment>
+        <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale. 
+        HeLx empowers researchers, students and educators to leverage advanced analytical tools without installation or other infrastructure concerns, which has broad reaching benefits and can be applied in many domains.
+        <br />&nbsp;<br />
+        The HeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
+        </Fragment>
+      );
 
-      if (!context.login_text) {
-        context.login_text = (
-          <Fragment>
-          <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale. 
-          HeLx empowers researchers, students and educators to leverage advanced analytical tools without installation or other infrastructure concerns, which has broad reaching benefits and can be applied in many domains.
-          <br />&nbsp;<br />
-          The HeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
-          </Fragment>
-        )
-      }
-      else {
-        context.login_text = (<Fragment>Testing out read</Fragment>)
-        fetch('https://raw.githubusercontent.com/helxplatform/appstore/test-hs/appstore/core/static/html/test-read.html')
-        .then(response => {
+      const getLoginDesc = async () => {
+        console.log(`${relativeHost}/static/frontend/brand_desc.html`)
+        try{
+          let response = await fetch(`${relativeHost}/static/frontend/brand_desc.html`)
           if (!response.ok) {
-            throw new Error('Network response was not ok');
+            context.login_text = default_login_text
           }
-          return response.text();
-        })
-        .then(text => {
-          console.log('File contents:', text);
-          context.login_text = ( <Fragment>
-            <div dangerouslySetInnerHTML={{ __html: text }} />
-            </Fragment> )
-        })
-        .catch(error => {
-          console.error('There was a problem with the fetch operation:', error);
-        });
+          const htmlContent = await response.text();
+          console.log("*** GOT THE TEXT: ", htmlContent);
+          context.login_text = ( 
+            <Fragment>
+            <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
+            </Fragment> 
+          )
+        } catch (error) {
+          console.log("Error reading description file, reverting to default values")
+          context.login_text = default_login_text;
+        }
       }
-      // switch (context.brand) {
-      //   case "eduhelx":
-      //     context.login_text = (
-      //       <Fragment>
-      //         <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale. 
-      //         EduHeLx, which is a derivative of HeLx, is designed for educational purposes.
-      //         HeLx/EduHeLx empower researchers, students and educators to leverage advanced analytical tools without installation or other infrastructure concerns, which has broad reaching benefits and can be applied in many domains.
-      //         <br />&nbsp;<br />
-      //         The HeLx and EduHeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
-      //       </Fragment>
-      //     )
-      //     break
-      //   default:
-      //     context.login_text = (
-      //       <Fragment>
-      //         <a href="https://helxplatform.github.io/">HeLx</a> empowers researchers in domains from plant genomics to neuroscience to work with their preferred tools and apps in the cloud at scale.
-      //         Its ability to empower researchers to leverage advanced analytical tools without installation or other infrastructure concerns has broad reaching benefits and can be applied in many domains.
-      //         <br />&nbsp;<br />
-      //         The HeLx Workspaces provide a wide array of data science tools for use by these researchers. Through the Workspaces, users explore and interact with analytic tools and data to support scientific discovery.
-      //       </Fragment>
-      //     )
-      //     break
-      // }
+      getLoginDesc();
 
       // split the comma-separated string which tells ui the support section to hide
       // also trim leading/trailing spaces to allow spaces between commas

--- a/src/contexts/workspaces-context/api.types.ts
+++ b/src/contexts/workspaces-context/api.types.ts
@@ -101,6 +101,8 @@ export interface EnvironmentContext {
         primary: string
         secondary: string
     }
+    login_text: string
+    login_title: string
     links: ExtraLink[]
     capabilities: Capability[]
     dockstore_app_specs_dir_url: string

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -6,88 +6,7 @@ import {faqsOpened, userGuideOpened} from "../contexts/analytics-context/events/
 
 const { Title } = Typography
 
-// Support page sections can be hidden using hidden_sections in the configuration. <community, support>
-
-// const CommunitySupport = () =>
-//   <Fragment>
-//     <Title level={1}>Community Support</Title>
-//     <Typography>Your HeLx community has access to it&apos;s own Discourse, a community-driven forum that provides help and guidance to any HeLx question you may have. On Discourse, you will find members of the HeLx engineering and product management team, as well as other members of your community. Here you can ask questions, answer questions, and engage in community-building for your specific instance of HeLx.</Typography>
-//     <br />
-//     <Typography>Please visit <a href="https://community.helx.renci.org/invites/B2dnCA8xRi" target="_blank" rel="noopener noreferrer">community.helx.renci.org</a> today to create your account, and to join in the discourse!</Typography>
-//   </Fragment>
-
-// const Documentation = () =>
-//   <Fragment>
-//     <Title level={1}>Documentation</Title>
-//     <Typography>Our documentation is designed to help guide you through your first steps with HeLx. We encourage you to get started with these introductory guides</Typography>
-//     <ul>
-//       <li><a href="https://helx.gitbook.io/helx-documentation/helx/starting-an-existing-app" target="_blank" rel="noopener noreferrer"><b>Logging in and starting an app</b></a> - Authentication requires a <a href="https://github.com/" target="_blank" rel="noopener noreferrer"><b>Github</b></a> or <a href="https://accounts.google.com/SignUp?hl=en" target="_blank" rel="noopener noreferrer"><b>Google</b></a> account</li>
-//       <li><a href="https://helx.gitbook.io/helx-documentation/helx/application-management" target="_blank" rel="noopener noreferrer"><b>Managing your apps</b></a> - Learn how to change GPU and CPU resources, rename an app instance, and delete your running apps</li>
-//       <li><a href="https://helx.gitbook.io/helx-documentation/dug/using-search" target="_blank" rel="noopener noreferrer"><b>Using search</b></a> - Familiarize yourself with Dug, the HeLx search space</li>
-//       <li><a href="https://helx.gitbook.io/helx-documentation/dug/technical-documents" target="_blank" rel="noopener noreferrer"><b>More technical documentation</b></a> - Dive deeper into the HeLx platform and the underlying architecture</li>
-//     </ul>
-//   </Fragment>
-
-// const HEALSupport = () => {
-//   const { analyticsEvents } = useAnalytics()
-//   return (
-//     <Fragment>
-//         <Title level={1}>Need Help?</Title>
-//         <div style={{ fontSize: 15 }}>
-//           <Typography>To report a bug, request technical assistance, submit user feedback, or submit a different request, visit our Help Portal.</Typography>
-//           <ul>
-//               <li>
-//                 <a
-//                   href="http://bit.ly/HEALSemanticSearch_Help"
-//                   target="_blank"
-//                   rel="noopener noreferrer"
-//                   onClick={ () => {
-//                     analyticsEvents.helpPortalOpened()
-//                   } }
-//                 >
-//                   <b>Help Portal</b>
-//                 </a>
-//               </li>
-//           </ul>
-//         </div>
-
-//         <Title level={1} style={{ marginTop: 16 }}>Documentation</Title>
-//         <div style={{ fontSize: 15 }}>
-//           <Typography>
-//               Our documentation is designed to help guide you through your first steps with HEAL Semantic Search.
-//               We encourage you to get started with these introductory materials.
-//           </Typography>
-//           <ul>
-//               <li>
-//                   <a
-//                       href="https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1"
-//                       target="_blank"
-//                       rel="noopener noreferrer"
-//                       onClick={ () => {
-//                           analyticsEvents.userGuideOpened()
-//                       } }
-//                   >
-//                       <b>User Guide</b>
-//                   </a>
-//               </li>
-//               <li>
-//                   <a
-//                       href="https://docs.google.com/document/d/1njtRJbdHePRE-1kYtmyli-NqVuwU9bdqZ-42RNQGpBI/edit"
-//                       target="_blank"
-//                       rel="noopener noreferrer"
-//                       onClick={ () => {
-//                           analyticsEvents.faqsOpened()
-//                       } }
-//                   >
-//                     <b>FAQs</b>
-//                   </a>
-//               </li>
-//           </ul>
-//         </div>
-//     </Fragment>
-//   )
-// }
-
+// This section points to a portal to report bugs, submit feedback, or feature requests for the deployments.
 const HelpPortal = (context) =>{
   const { analyticsEvents } = useAnalytics()
   return (
@@ -98,7 +17,7 @@ const HelpPortal = (context) =>{
           <ul>
               <li>
                 <a
-                  //href="http://bit.ly/HEALSemanticSearch_Help"
+                  //example href="http://bit.ly/HEALSemanticSearch_Help"
                   href={context.help_portal_url}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -115,12 +34,13 @@ const HelpPortal = (context) =>{
   )
 }
 
+// This section links to a user documentation.
 const UserGuide = (context) => {
   const { analyticsEvents } = useAnalytics()
   return (
       <li>
           <a
-              //href="https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1"
+              //example href="https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1"
               href = {context.user_guide_url}
               target="_blank"
               rel="noopener noreferrer"
@@ -134,6 +54,7 @@ const UserGuide = (context) => {
   )
  }
 
+ // This section points a link with FAQs.
  const Faqs = (context) => {
   const { analyticsEvents } = useAnalytics()
   return (
@@ -152,6 +73,7 @@ const UserGuide = (context) => {
   )
  }
 
+ // This section combines user guide, and faqs together.
  const Documentation = (context) => {
   return (
     <Fragment>
@@ -181,8 +103,4 @@ export const SupportView = () => {
     </Fragment>
   )
 }
-
-// {/* {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('community') && <CommunitySupport />} */}
-// {/* {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('documentation') && <Documentation />} */}
-// {/* {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('heal-support') && <HEALSupport />} */}
       

--- a/src/views/support.js
+++ b/src/views/support.js
@@ -8,27 +8,87 @@ const { Title } = Typography
 
 // Support page sections can be hidden using hidden_sections in the configuration. <community, support>
 
-const CommunitySupport = () =>
-  <Fragment>
-    <Title level={1}>Community Support</Title>
-    <Typography>Your HeLx community has access to it&apos;s own Discourse, a community-driven forum that provides help and guidance to any HeLx question you may have. On Discourse, you will find members of the HeLx engineering and product management team, as well as other members of your community. Here you can ask questions, answer questions, and engage in community-building for your specific instance of HeLx.</Typography>
-    <br />
-    <Typography>Please visit <a href="https://community.helx.renci.org/invites/B2dnCA8xRi" target="_blank" rel="noopener noreferrer">community.helx.renci.org</a> today to create your account, and to join in the discourse!</Typography>
-  </Fragment>
+// const CommunitySupport = () =>
+//   <Fragment>
+//     <Title level={1}>Community Support</Title>
+//     <Typography>Your HeLx community has access to it&apos;s own Discourse, a community-driven forum that provides help and guidance to any HeLx question you may have. On Discourse, you will find members of the HeLx engineering and product management team, as well as other members of your community. Here you can ask questions, answer questions, and engage in community-building for your specific instance of HeLx.</Typography>
+//     <br />
+//     <Typography>Please visit <a href="https://community.helx.renci.org/invites/B2dnCA8xRi" target="_blank" rel="noopener noreferrer">community.helx.renci.org</a> today to create your account, and to join in the discourse!</Typography>
+//   </Fragment>
 
-const Documentation = () =>
-  <Fragment>
-    <Title level={1}>Documentation</Title>
-    <Typography>Our documentation is designed to help guide you through your first steps with HeLx. We encourage you to get started with these introductory guides</Typography>
-    <ul>
-      <li><a href="https://helx.gitbook.io/helx-documentation/helx/starting-an-existing-app" target="_blank" rel="noopener noreferrer"><b>Logging in and starting an app</b></a> - Authentication requires a <a href="https://github.com/" target="_blank" rel="noopener noreferrer"><b>Github</b></a> or <a href="https://accounts.google.com/SignUp?hl=en" target="_blank" rel="noopener noreferrer"><b>Google</b></a> account</li>
-      <li><a href="https://helx.gitbook.io/helx-documentation/helx/application-management" target="_blank" rel="noopener noreferrer"><b>Managing your apps</b></a> - Learn how to change GPU and CPU resources, rename an app instance, and delete your running apps</li>
-      <li><a href="https://helx.gitbook.io/helx-documentation/dug/using-search" target="_blank" rel="noopener noreferrer"><b>Using search</b></a> - Familiarize yourself with Dug, the HeLx search space</li>
-      <li><a href="https://helx.gitbook.io/helx-documentation/dug/technical-documents" target="_blank" rel="noopener noreferrer"><b>More technical documentation</b></a> - Dive deeper into the HeLx platform and the underlying architecture</li>
-    </ul>
-  </Fragment>
+// const Documentation = () =>
+//   <Fragment>
+//     <Title level={1}>Documentation</Title>
+//     <Typography>Our documentation is designed to help guide you through your first steps with HeLx. We encourage you to get started with these introductory guides</Typography>
+//     <ul>
+//       <li><a href="https://helx.gitbook.io/helx-documentation/helx/starting-an-existing-app" target="_blank" rel="noopener noreferrer"><b>Logging in and starting an app</b></a> - Authentication requires a <a href="https://github.com/" target="_blank" rel="noopener noreferrer"><b>Github</b></a> or <a href="https://accounts.google.com/SignUp?hl=en" target="_blank" rel="noopener noreferrer"><b>Google</b></a> account</li>
+//       <li><a href="https://helx.gitbook.io/helx-documentation/helx/application-management" target="_blank" rel="noopener noreferrer"><b>Managing your apps</b></a> - Learn how to change GPU and CPU resources, rename an app instance, and delete your running apps</li>
+//       <li><a href="https://helx.gitbook.io/helx-documentation/dug/using-search" target="_blank" rel="noopener noreferrer"><b>Using search</b></a> - Familiarize yourself with Dug, the HeLx search space</li>
+//       <li><a href="https://helx.gitbook.io/helx-documentation/dug/technical-documents" target="_blank" rel="noopener noreferrer"><b>More technical documentation</b></a> - Dive deeper into the HeLx platform and the underlying architecture</li>
+//     </ul>
+//   </Fragment>
 
-const HEALSupport = () => {
+// const HEALSupport = () => {
+//   const { analyticsEvents } = useAnalytics()
+//   return (
+//     <Fragment>
+//         <Title level={1}>Need Help?</Title>
+//         <div style={{ fontSize: 15 }}>
+//           <Typography>To report a bug, request technical assistance, submit user feedback, or submit a different request, visit our Help Portal.</Typography>
+//           <ul>
+//               <li>
+//                 <a
+//                   href="http://bit.ly/HEALSemanticSearch_Help"
+//                   target="_blank"
+//                   rel="noopener noreferrer"
+//                   onClick={ () => {
+//                     analyticsEvents.helpPortalOpened()
+//                   } }
+//                 >
+//                   <b>Help Portal</b>
+//                 </a>
+//               </li>
+//           </ul>
+//         </div>
+
+//         <Title level={1} style={{ marginTop: 16 }}>Documentation</Title>
+//         <div style={{ fontSize: 15 }}>
+//           <Typography>
+//               Our documentation is designed to help guide you through your first steps with HEAL Semantic Search.
+//               We encourage you to get started with these introductory materials.
+//           </Typography>
+//           <ul>
+//               <li>
+//                   <a
+//                       href="https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1"
+//                       target="_blank"
+//                       rel="noopener noreferrer"
+//                       onClick={ () => {
+//                           analyticsEvents.userGuideOpened()
+//                       } }
+//                   >
+//                       <b>User Guide</b>
+//                   </a>
+//               </li>
+//               <li>
+//                   <a
+//                       href="https://docs.google.com/document/d/1njtRJbdHePRE-1kYtmyli-NqVuwU9bdqZ-42RNQGpBI/edit"
+//                       target="_blank"
+//                       rel="noopener noreferrer"
+//                       onClick={ () => {
+//                           analyticsEvents.faqsOpened()
+//                       } }
+//                   >
+//                     <b>FAQs</b>
+//                   </a>
+//               </li>
+//           </ul>
+//         </div>
+//     </Fragment>
+//   )
+// }
+
+const HelpPortal = (context) =>{
   const { analyticsEvents } = useAnalytics()
   return (
     <Fragment>
@@ -38,7 +98,8 @@ const HEALSupport = () => {
           <ul>
               <li>
                 <a
-                  href="http://bit.ly/HEALSemanticSearch_Help"
+                  //href="http://bit.ly/HEALSemanticSearch_Help"
+                  href={context.help_portal_url}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={ () => {
@@ -50,53 +111,78 @@ const HEALSupport = () => {
               </li>
           </ul>
         </div>
-
-        <Title level={1} style={{ marginTop: 16 }}>Documentation</Title>
-        <div style={{ fontSize: 15 }}>
-          <Typography>
-              Our documentation is designed to help guide you through your first steps with HEAL Semantic Search.
-              We encourage you to get started with these introductory materials.
-          </Typography>
-          <ul>
-              <li>
-                  <a
-                      href="https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={ () => {
-                          analyticsEvents.userGuideOpened()
-                      } }
-                  >
-                      <b>User Guide</b>
-                  </a>
-              </li>
-              <li>
-                  <a
-                      href="https://docs.google.com/document/d/1njtRJbdHePRE-1kYtmyli-NqVuwU9bdqZ-42RNQGpBI/edit"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={ () => {
-                          analyticsEvents.faqsOpened()
-                      } }
-                  >
-                    <b>FAQs</b>
-                  </a>
-              </li>
-          </ul>
-        </div>
     </Fragment>
   )
 }
+
+const UserGuide = (context) => {
+  const { analyticsEvents } = useAnalytics()
+  return (
+      <li>
+          <a
+              //href="https://docs.google.com/document/d/1M43Ex0eg_ObvXIGvWFUuwqKAYpWATXa8vYSpB5gUa6Q/edit?pli=1"
+              href = {context.user_guide_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={ () => {
+                  analyticsEvents.userGuideOpened()
+              } }
+          >
+              <b>User Guide</b>
+          </a>
+      </li>
+  )
+ }
+
+ const Faqs = (context) => {
+  const { analyticsEvents } = useAnalytics()
+  return (
+      <li>
+          <a
+              href= {context.faqs_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={ () => {
+                  analyticsEvents.faqsOpened()
+              } }
+          >
+            <b>FAQs</b>
+          </a>
+      </li>
+  )
+ }
+
+ const Documentation = (context) => {
+  return (
+    <Fragment>
+        <Title level={1}>Documentation</Title>
+        <Typography>
+          Our documentation is designed to help guide you through your first steps. 
+          We encourage you to get started with these introductory guides
+        </Typography>
+        <ul>
+          {context.user_guide_url && <UserGuide user_guide_url={context.user_guide_url} />}
+          {context.faqs_url && <Faqs faqs_url={context.faqs_url} />}
+        </ul>
+      </Fragment>
+  )
+ }
+
+
 
 export const SupportView = () => {
   const { context } = useEnvironment()
   useTitle("Support")
-
+  console.log(context.support.help_portal_url)
   return (
     <Fragment>
-      {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('community') && <CommunitySupport />}
-      {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('documentation') && <Documentation />}
-      {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('heal-support') && <HEALSupport />}
+      {context.support.help_portal_url && <HelpPortal help_portal_url={context.support.help_portal_url} />}
+      {(context.support.user_guide_url || context.support.faqs_url) && <Documentation user_guide_url={context.support.user_guide_url} faqs_url={context.support.faqs_url}/>}
     </Fragment>
   )
 }
+
+// {/* {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('community') && <CommunitySupport />} */}
+// {/* {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('documentation') && <Documentation />} */}
+// {/* {Array.isArray(context.hidden_support_sections) && !context.hidden_support_sections.includes('heal-support') && <HEALSupport />} */}
+      

--- a/src/views/workspaces/login/login.js
+++ b/src/views/workspaces/login/login.js
@@ -180,7 +180,7 @@ export const WorkspaceLoginView = withAPIReady(({
                             </Button>
                         )
                     }}
-                    title="HeLx Workspaces"
+                    title= { context.login_title }
                     logo={ <AppstoreOutlined /> }
                     subTitle={
                         !asComponent ? <Paragraph style={{ fontSize: 14, maxWidth: 800, margin: "0 auto" }}>

--- a/src/views/workspaces/login/signup.js
+++ b/src/views/workspaces/login/signup.js
@@ -158,7 +158,7 @@ export const WorkspaceSignupView = withSocialSignupAllowed(({
                             </Button>
                         )
                     }}
-                    title="HeLx Workspaces"
+                    title={ context.login_title }
                     logo={ <AppstoreOutlined /> }
                     subTitle={
                         <div style={{ display: "flex", flexDirection: "column" }}>


### PR DESCRIPTION
This PR adds support for the following configurable options:

- ENV variable `REACT_APP_SUPPORT_HELP_PORTAL_URL` : Will link to a help portal for the deployment (configurable as a helm chart value). The corresponding section will show up only when this values is available. Default is empty. 
- ENV variable `REACT_APP_SUPPORT_USER_GUIDE_URL`: Will link to the user guide for the deployment (configurable as a helm chart value). The corresponding section will show up under `Documentation` only when this value is available. Default is empty.
- ENV variable `REACT_APP_SUPPORT_FAQS_URL`: Will link to a faqs page/document for the deployment (configurable as a helm chart value). The corresponding section will show up under `Documentation` only when this value is provided. Default is empty
- ENV variable `REACT_APP_LOGIN_TITLE`: Login page heading text. If this is empty, the login title becomes `<REACT_APP_META_TITLE> Workspaces`. Default is kept empty, because usually a title for the deployment is provided, and the login page is to workspaces. But the environment variable lets it become something else if requested.
- Login page description text (as html code) will be read from a helm-chart mounted file into `static/frontend/brand_desc.html` file. Helm chart will upload the correct file based on brand. There's default text available when needed.

Screen shot for Support page when all the links provided:
![image](https://github.com/helxplatform/helx-ui/assets/22948571/1cb82efe-23e8-4e26-84b6-da013b1486c2)

Screen shot for Support page when FAQs are not provided:
![image](https://github.com/helxplatform/helx-ui/assets/22948571/4c7e4f42-3e5f-4d34-b30f-b5bb44e9e1cd)
