### PR TITLE
fix typo in concept modal tab css

### DIFF
--- a/src/components/search/concept-modal/concept-modal.css
+++ b/src/components/search/concept-modal/concept-modal.css
@@ -57,7 +57,7 @@
 }
 .concept-modal-tabs .ant-menu-title-content > .tab-menu-item-wrapper {
   padding-left: 24px;
-  padding-right: 16;
+  padding-right: 16px;
 }
 
 .concept-modal-body > .ant-space-item:nth-child(2) {


### PR DESCRIPTION
fixes a typo in css introduced by guided tour PR.