### PR TITLE
fix backtop styling

### DIFF
--- a/src/components/layout/back-top.js
+++ b/src/components/layout/back-top.js
@@ -16,9 +16,12 @@ export const BackTop = ({ style={}, ...props }) => {
     >
       <div className="ant-back-top-content" style={{
         color: "#fff",
-        backgroundColor: "#1088e9"
+        backgroundColor: "#1088e9",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center"
       }}>
-        <ArrowUpOutlined className="ant-back-top-icon" style={{ fontSize: "20px", marginTop: "2px" }} />
+        <ArrowUpOutlined className="ant-back-top-icon" style={{ fontSize: "20px" }} />
       </div>
     </AntBackTop>
   )


### PR DESCRIPTION
Really not sure how this happened but backtop styling for some reason was no longer centering the arrow in its container.