### PR TITLE
TranQL query optimization, loading error/state improvements, variable view color fix

### DIFF
--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -153,7 +153,7 @@ export const ConceptModalBody = ({ result }) => {
       content: <KnowledgeGraphsTab graphs={ graphs } loading={ graphsLoading } error={ graphsError } />,
       tooltip: <div>
         The Knowledge Graphs tab displays relevant edges from the <a href="https://robokop.renci.org/" target="_blank" rel="noopener noreferrer">ROBOKOP Knowledge Graph</a>
-        portion connected to the concept and containing your search terms. This section highlights
+        &nbsp;portion connected to the concept and containing your search terms. This section highlights
         potential interesting knowledge graph relationships and shows terms (e.g., synonyms) that
         would be returned as related concepts.
       </div>
@@ -218,7 +218,7 @@ export const ConceptModalBody = ({ result }) => {
         }, {}))
       } catch (e) {
         if (e.name !== "CanceledError") {
-          console.error(e)
+          console.warning(e)
           setStudies(null)
         }
       }
@@ -316,7 +316,9 @@ export const ConceptModalBody = ({ result }) => {
           const cdeIds = cdeData.elements.map((cde) => cde.id)
           await Promise.all(cdeIds.map(async (cdeId, i) => {
             try {
-              relatedConcepts[cdeId] = await loadRelatedConcepts(cdeId)
+              const relatedConceptsRaw = await loadRelatedConcepts(cdeId)
+              // Counterproductive to suggest the concept the user is actively viewing as "related"
+              relatedConcepts[cdeId] = relatedConceptsRaw.filter((c) => c.id !== result.id)
             } catch (e) {
               // Here, we explicitly want to halt execution and forward this error to the outer handler
               // if a related concept request was aborted, because we now have stale data and don't want to
@@ -343,7 +345,7 @@ export const ConceptModalBody = ({ result }) => {
       } catch (e) {
         // Check both because this function uses both Fetch API & Axios
         if (e.name !== "CanceledError" && e.name !== "AbortError") {
-          console.error(e)
+          console.warning(e)
           setCdes(null)
         }
       }
@@ -359,7 +361,7 @@ export const ConceptModalBody = ({ result }) => {
         setGraphs(kgs)
       } catch (e) {
         if (e.name !== "CanceledError") {
-          console.error(e)
+          console.warning(e)
           setGraphs(null)
         }
       }

--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -240,6 +240,7 @@ export const ConceptModalBody = ({ result }) => {
           const tranqlUrl = context.tranql_url
           const controller = new AbortController()
           fetchCdesTranqlController.current.push(controller)
+          
           const res = await fetch(
             `${tranqlUrl}tranql/query`,
             {
@@ -354,25 +355,29 @@ export const ConceptModalBody = ({ result }) => {
       ]}
       className="concept-modal-failed-result"
     >
-      <Paragraph style={{ marginBottom: 0 }}>
-        <Text strong style={{ fontSize: 16 }}>Related concepts</Text>
-      </Paragraph>
-      <div>
-        {
-          result.suggestions
-            .slice(0, 8)
-            .map((suggestedResult) => (
-              <a
-                key={ suggestedResult.id }
-                role="button"
-                style={{ display: "inline", marginRight: "12px", lineHeight: "36px" }}
-                onClick={() => setSelectedResult(suggestedResult)}
-              >
-                {suggestedResult.name}
-              </a>
-            ))
-        }
-      </div>
+      { result.suggestions && (
+        <Fragment>
+          <Paragraph style={{ marginBottom: 0 }}>
+            <Text strong style={{ fontSize: 16 }}>Related concepts</Text>
+          </Paragraph>
+          <div>
+            {
+              result.suggestions
+                .slice(0, 8)
+                .map((suggestedResult) => (
+                  <a
+                    key={ suggestedResult.id }
+                    role="button"
+                    style={{ display: "inline", marginRight: "12px", lineHeight: "36px" }}
+                    onClick={() => setSelectedResult(suggestedResult)}
+                  >
+                    {suggestedResult.name}
+                  </a>
+                ))
+            }
+          </div>
+        </Fragment>
+      ) }
     </Result>
   )
   return (

--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -233,108 +233,58 @@ export const ConceptModalBody = ({ result }) => {
         const cdeData = await fetchCDEs(result.id, query, {
           signal: fetchCdesController.current.signal
         })
-        const loadRelatedConcepts = async (cdeId) => {
-          const formatCdeQuery = (conceptType) => {
-            return `\
-      SELECT publication-[mentions]->${conceptType}
-      FROM "/schema"
-      WHERE publication="${cdeId}"`
-          }
-          const tranqlUrl = context.tranql_url
-          const types = ['disease', 'anatomical_entity', 'phenotypic_feature', 'biological_process'] // add any others that you can think of, these are the main 4 found in heal results and supported by tranql
-          const kg = (await Promise.all(types.map(async (type) => {
-              const controller = new AbortController()
-              fetchCdesTranqlController.current.push(controller)
-              const res = await fetch(
-                  `${tranqlUrl}tranql/query`,
-                  {
-                      headers: { 'Content-Type': 'text/plain' },
-                      method: 'POST',
-                      body: formatCdeQuery(type),
-                      signal: controller.signal
-                  }
-              )
-              const message = await res.json()
-              return message.message.knowledge_graph
-          }))).reduce((acc, kg) => ({
-              nodes: {
-                  ...acc.nodes,
-                  ...kg.nodes
-              },
-              edges: {
-                  ...acc.edges,
-                  ...kg.edges
-              }
-          }), {"nodes": {}, "edges": {}})
-          const cdeOutEdges = Object.values(kg.edges).filter((edge) => edge.subject ===  cdeId)
-          return cdeOutEdges.map(
-            (outEdge) => {
-              const [nodeId, node] = Object.entries(kg.nodes).find(([nodeId, node]) => nodeId === outEdge.object)
-              return {
-                id: nodeId,
-                ...node
-              }
-            }
-          )
-        }
-
-        const loadRelatedStudies = async (cdeId) => {
-          const formatCdeQuery = () => {
-            return `\
-      SELECT publication->study
-      FROM "/schema"
-      WHERE publication="${cdeId}"`
+        const loadRelatedConceptsAndStudies = async (cdeId) => {
+          const getNodeAttribute = (node, attrName) => {
+            return node.attributes.find((attr) => attr.name === attrName)
           }
           const tranqlUrl = context.tranql_url
           const controller = new AbortController()
           fetchCdesTranqlController.current.push(controller)
           const res = await fetch(
-              `${tranqlUrl}tranql/query`,
-              {
-                  headers: { 'Content-Type': 'text/plain' },
-                  method: 'POST',
-                  body: formatCdeQuery(),
-                  signal: controller.signal
-              }
+            `${tranqlUrl}tranql/query`,
+            {
+                headers: { 'Content-Type': 'text/plain' },
+                method: 'POST',
+                body: `SELECT publication->named_thing FROM "redis:" WHERE publication="${cdeId}"`,
+                signal: controller.signal
+            }
           )
           const message = await res.json()
-          const studies = []
-          const nodes =  message.message.knowledge_graph.nodes
-          for (const [key, value] of Object.entries(nodes)) {
-            const name = value.name;
-            const urlAttribute = value.attributes.find(attr => attr.name === 'url');
-            urlAttribute && studies.push({c_id: key,
-                                          c_name: name,
-                                          c_link: urlAttribute.value});
-          }
-          return studies
+          const kg = message.message.knowledge_graph
+          const cdeOutEdges = Object.values(kg.edges).filter((edge) => edge.subject ===  cdeId)
+          return cdeOutEdges.map(({ object }) => kg.nodes[object])
+            .reduce((acc, node) => {
+              const [relatedConceptNodes, relatedStudyNodes] = acc
+              const types = getNodeAttribute(node, "category")
+              const url = getNodeAttribute(node, "url")
+              if (url && types && types.value.includes("biolink:Study")) relatedStudyNodes.push({
+                c_id: node.id,
+                c_name: node.name,
+                c_link: url.value
+              })
+              else relatedConceptNodes.push(node)
+              return [relatedConceptNodes, relatedStudyNodes]
+            }, [[], []])
         }
-
+        
         const relatedConcepts = {}
         const relatedStudies = {}
         if (cdeData) {
           const cdeIds = cdeData.elements.map((cde) => cde.id)
           await Promise.all(cdeIds.map(async (cdeId, i) => {
             try {
-              const relatedConceptsRaw = await loadRelatedConcepts(cdeId)
+              const [relatedConceptsRaw, relatedStudiesRaw] = await loadRelatedConceptsAndStudies(cdeId)
               // Counterproductive to suggest the concept the user is actively viewing as "related"
+              console.log(relatedConceptsRaw, relatedStudiesRaw)
               relatedConcepts[cdeId] = relatedConceptsRaw.filter((c) => c.id !== result.id)
+              relatedStudies[cdeId] = relatedStudiesRaw
             } catch (e) {
+              console.log(e)
               // Here, we explicitly want to halt execution and forward this error to the outer handler
               // if a related concept request was aborted, because we now have stale data and don't want to
               // update state with it.
               if (e.name === "CanceledError" || e.name === "AbortError") throw e
               relatedConcepts[cdeId] = null
-            }
-          }))
-          await Promise.all(cdeIds.map(async (cdeId, i) => {
-            try {
-              relatedStudies[cdeId] = await loadRelatedStudies(cdeId)
-            } catch (e) {
-              // Here, we explicitly want to halt execution and forward this error to the outer handler
-              // if a related concept request was aborted, because we now have stale data and don't want to
-              // update state with it.
-              if (e.name === "CanceledError" || e.name === "AbortError") throw e
             }
           }))
         }

--- a/src/components/search/concept-modal/concept-modal.js
+++ b/src/components/search/concept-modal/concept-modal.js
@@ -275,11 +275,9 @@ export const ConceptModalBody = ({ result }) => {
             try {
               const [relatedConceptsRaw, relatedStudiesRaw] = await loadRelatedConceptsAndStudies(cdeId)
               // Counterproductive to suggest the concept the user is actively viewing as "related"
-              console.log(relatedConceptsRaw, relatedStudiesRaw)
               relatedConcepts[cdeId] = relatedConceptsRaw.filter((c) => c.id !== result.id)
               relatedStudies[cdeId] = relatedStudiesRaw
             } catch (e) {
-              console.log(e)
               // Here, we explicitly want to halt execution and forward this error to the outer handler
               // if a related concept request was aborted, because we now have stale data and don't want to
               // update state with it.

--- a/src/components/search/concept-modal/tabs/cdes/cde-item.js
+++ b/src/components/search/concept-modal/tabs/cdes/cde-item.js
@@ -28,11 +28,11 @@ export const CdeItem = ({ cde, cdeRelatedConcepts, cdeRelatedStudies, highlight 
     const { analyticsEvents } = useAnalytics()
 
     const relatedConceptsSource = useMemo(() => (
-        cdeRelatedConcepts[cde.id]
+        cdeRelatedConcepts ? cdeRelatedConcepts[cde.id] : null
     ), [cdeRelatedConcepts, cde])
 
     const relatedStudySource = useMemo(() => (
-        cdeRelatedStudies[cde.id]
+        cdeRelatedStudies ? cdeRelatedStudies[cde.id] : null
     ), [cdeRelatedStudies, cde])
 
     const Highlighter = useCallback(({ ...props }) => (

--- a/src/components/search/concept-modal/tabs/cdes/cdes.js
+++ b/src/components/search/concept-modal/tabs/cdes/cdes.js
@@ -11,12 +11,12 @@ const { Text, Title } = Typography
 const { CheckableTag: CheckableFacet } = Tag
 const { Panel } = Collapse
 
-export const CdesTab = ({ cdes, cdeRelatedConcepts, cdeRelatedStudies, loading }) => {
+export const CdesTab = ({ cdes, cdeRelatedConcepts, cdeRelatedStudies, loading, error }) => {
   const [search, setSearch] = useState("")
   const { context } = useEnvironment()
 
-  /** CDEs have loaded, but there aren't any. */
-  const failed = useMemo(() => !loading && !cdes, [loading, cdes])
+  /** CDEs failed to load or loaded but no results. */
+  const failed = useMemo(() => error && !cdes, [error, cdes])
 
   const docs = useMemo(() => {
     if (!loading && !failed) {

--- a/src/components/search/concept-modal/tabs/cdes/cdes.js
+++ b/src/components/search/concept-modal/tabs/cdes/cdes.js
@@ -27,7 +27,7 @@ export const CdesTab = ({ cdes, cdeRelatedConcepts, cdeRelatedStudies, loading, 
         // Lunr supports array fields, though it expects the user to tokenize the elements themselves.
         // Instead, just join the concepts into a string and let lunr tokenize it instead.
         // See: https://stackoverflow.com/a/43562885
-        concepts: Object.values(cdeRelatedConcepts[cde.id] ?? []).map((concept) => concept.name).join(" ")
+        concepts: cdeRelatedConcepts ? Object.values(cdeRelatedConcepts[cde.id] ?? []).map((concept) => concept.name).join(" ") : []
       }))
     } else return []
   }, [loading, failed, cdes, cdeRelatedConcepts])

--- a/src/components/search/concept-modal/tabs/studies/study.js
+++ b/src/components/search/concept-modal/tabs/studies/study.js
@@ -29,7 +29,7 @@ export const Study = ({ study, highlight, collapsed, ...panelProps }) => {
               (<Link to={ study.c_link } onClick={ studyLinkClicked }>{ study.c_id }</Link>)
             </Text>
           }
-          extra={ <Text style={{ whiteSpace: "nowrap" }}>{ study.elements.length } variable{ study.elements.length === 1 ? '' : 's' }</Text> }
+          extra={ <Text style={{ whiteSpace: "nowrap", marginLeft: 8 }}>{ study.elements.length } variable{ study.elements.length === 1 ? '' : 's' }</Text> }
           {...panelProps}
         >
           <StudyVariables variables={ study.elements } highlight={ highlight } />

--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -373,7 +373,7 @@ export const HelxSearch = ({ children }) => {
       }
       const filteredAndTypedStudies = Object.keys(result)
         .reduce((studies, key) => {
-          if (key !== "cde") {
+          if (key.toLowerCase() !== "cde") {
             const newStudies = [...result[key].map(item => ({ type: key, ...item }))]
             return [...newStudies, ...studies]
           }
@@ -400,7 +400,7 @@ export const HelxSearch = ({ children }) => {
       }
       const cdesOnly = Object.keys(result)
         .reduce((studies, key) => {
-          if (key === 'cde') {
+          if (key.toLowerCase() === 'cde') {
             const newStudies = [...result[key].map(item => ({ type: key, ...item }))]
             return [...newStudies, ...studies]
           }
@@ -528,6 +528,8 @@ export const HelxSearch = ({ children }) => {
           }, [])
           // Load non-indexed supplemental CDE attributes where applicable.
           const cdeVariables = studies.flatMap((s) => s.elements).filter((v) => isCDE(v))
+          /**
+           * Currently, don't load these. Not much useful info and requires 1 TranQL request per CDE returned.
           await Promise.all(cdeVariables.map(async (cde) => {
             try {
               const controller = new AbortController()
@@ -543,6 +545,7 @@ export const HelxSearch = ({ children }) => {
               }
             }
           }))
+          */
           // Data structure of sortedVariables is designed to populate the histogram feature
           const {sortedVariables, variablesCount, studiesWithVariablesMarked, studiesCount} = collectVariablesAndUpdateStudies(studies)
           setVariableStudyResults(studiesWithVariablesMarked)

--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -406,11 +406,14 @@ export const HelxSearch = ({ children }) => {
           }
           return [...studies]
         }, [])
-      return cdesOnly ? cdesOnly[0] : null
+      return cdesOnly.length > 0 ? cdesOnly[0] : null
     } catch (error) {
       /** Forward AbortError upwards. Handle other errors here. */
       if (error.name === "CanceledError") throw error
-      else console.error(error)
+      else {
+        console.error(error)
+        return null
+      }
     }
   }, [helxSearchUrl])
 

--- a/src/components/search/context.js
+++ b/src/components/search/context.js
@@ -158,7 +158,7 @@ export const HelxSearch = ({ children }) => {
       setSelectedResult(foundConceptResult ? foundConceptResult : {
         name,
         failed: true,
-        suggestions: synonymousConcepts.length > 0 ? synonymousConcepts : results
+        suggestions: synonymousConcepts?.length > 0 ? synonymousConcepts : null
       })
     } catch (e) {
       if (e.name !== "CanceledError") throw e

--- a/src/components/search/knowledge-graphs/knowledge-graphs.js
+++ b/src/components/search/knowledge-graphs/knowledge-graphs.js
@@ -1,4 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useState } from 'react'
+import { Result, Spin } from 'antd'
 import _Highlighter from 'react-highlight-words'
 import { kgLink } from '../../../utils'
 import { Link } from '../../link'
@@ -64,8 +65,16 @@ const NoKnowledgeGraphsMessage = () => {
   )
 }
 
-export const KnowledgeGraphs = ({ graphs: complete_graphs, highlight }) => {
-  if (complete_graphs.length) {
+export const KnowledgeGraphs = ({ graphs: complete_graphs, loading, error, highlight }) => {
+  if (loading) return (
+    <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+      <Spin />
+    </div>
+  )
+  else if (error) return (
+    <Result status="error" title="Oops!" subTitle="We&apos;re having trouble loading knowledge graphs right now. Please try again later..." />
+  )
+  else if (complete_graphs.length) {
     const graphs = complete_graphs.map((graph) => graph.knowledge_graph);
     return (
       <div className="interactions-grid">
@@ -88,6 +97,5 @@ export const KnowledgeGraphs = ({ graphs: complete_graphs, highlight }) => {
       </div>
     )
   }
-
-  return <NoKnowledgeGraphsMessage />
+  else return <NoKnowledgeGraphsMessage />
 }

--- a/src/components/search/results/variable-view-layout/variable-list/variable-list-item.tsx
+++ b/src/components/search/results/variable-view-layout/variable-list/variable-list-item.tsx
@@ -1,13 +1,33 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { Button, Tooltip, Typography } from 'antd'
+import { Button, Spin, Tooltip, Typography } from 'antd'
 import _Highlighter from 'react-highlight-words'
-import { useVariableView, VariableResult } from '../variable-view-context'
+import { CdeVariableResult, ISearchContext, useVariableView, VariableResult } from '../variable-view-context'
 import classNames from 'classnames'
 import { StudyInfoTooltip } from '../study-info-tooltip'
+import { useHelxSearch } from '../../../context'
 
 const { Text } = Typography
 
 const VARIABLE_DESCRIPTION_CUTOFF = 500
+
+interface VariableCdeAttributesProps {
+    // null indicates error state
+    attributes: { name: string, type: string, value: any }[] | null
+}
+
+const VariableCdeAttributes = ({ attributes }: VariableCdeAttributesProps) => {
+    const cdeCategories = useMemo<string[]>(() => attributes?.find((a) => a.name === "cde_categories")?.value, [attributes])
+    if (attributes === null) return (
+        null
+    )
+    else return (
+        <ul style={{ paddingLeft: 16, fontSize: 13 }}>
+            <li>
+                Categories: { cdeCategories!.sort((a, b) => a.localeCompare(b)).join(", ") }
+            </li>
+        </ul>
+    )
+}
 
 interface VariableListItemProps extends React.HTMLProps<HTMLDivElement> {
     variable: VariableResult
@@ -16,6 +36,7 @@ interface VariableListItemProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 export const VariableListItem = ({ variable, showStudySource=true, showDataSource=true, style={}, ...props }: VariableListItemProps) => {
+    const { isCDE } = useHelxSearch() as ISearchContext
     const { dataSources, highlightTokens, getStudyById } = useVariableView()!
     
     const [showMore, setShowMore] = useState<boolean>(false)
@@ -37,6 +58,7 @@ export const VariableListItem = ({ variable, showStudySource=true, showDataSourc
                 alignItems: "flex-start",
                 flexWrap: "nowrap",
                 paddingRight: 16,
+                gap: 4,
                 ...style
             }}
             { ...props }
@@ -93,6 +115,9 @@ export const VariableListItem = ({ variable, showStudySource=true, showDataSourc
                     </Button>
                 ) }
             </span>
+            { isCDE(variable) && (
+                <VariableCdeAttributes attributes={ variable.attributes } />
+            ) }
             { showStudySource && (
                 <span style={{ display: "inline-flex", alignItems: "center", fontSize: 12, color: "rgba(0, 0, 0, 0.45)" }}>
                     Source:&nbsp;<i>

--- a/src/components/search/results/variable-view-layout/variable-list/variable-list-item.tsx
+++ b/src/components/search/results/variable-view-layout/variable-list/variable-list-item.tsx
@@ -17,9 +17,7 @@ interface VariableCdeAttributesProps {
 
 const VariableCdeAttributes = ({ attributes }: VariableCdeAttributesProps) => {
     const cdeCategories = useMemo<string[]>(() => attributes?.find((a) => a.name === "cde_categories")?.value, [attributes])
-    if (attributes === null) return (
-        null
-    )
+    if (!attributes) return null
     else return (
         <ul style={{ paddingLeft: 16, fontSize: 13 }}>
             <li>


### PR DESCRIPTION
- Related concept & related variable queries are now performed as a single TranQL query per CDE. Before, related studies required 1 query and related concepts required 5 queries for a total of 6 queries per CDE.
- Adds loading/error states to the studies and knowledge graph tabs in the concept model. Previously, it seemed they were relying on their API requests completing fairly quickly and not failing.
- Fixes coloring of study sources in the variable view for certain searches.
- Fixes context to support capitalized "CDE" study/data sources (currently "cde" for both)