### PR TITLE
Fix hardcoded github value in production favicon loading

### DIFF
--- a/bin/create_index
+++ b/bin/create_index
@@ -9,11 +9,13 @@ fi
 title="${META_TITLE:-HeLx UI}"
 description="${META_DESCRIPTION:-HeLx UI}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
+appstore_asset_base_url="${REACT_APP_APPSTORE_ASSET_BASE_URL}"
 appstore_asset_branch="${REACT_APP_APPSTORE_ASSET_BRANCH}"
 
 cat "$1/index_template.html" | sed \
   -e "s/%META_TITLE%/$title/" \
   -e "s/%META_DESCRIPTION%/$description/" \
   -e "s/%BRAND%/$brand_name/" \
+  -e "s/%APPSTORE_ASSET_BASE_URL%/$appstore_asset_base_url/" \
   -e "s/%APPSTORE_ASSET_BRANCH%/$appstore_asset_branch/" \
   > $1/index.html

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -7,7 +7,7 @@
       type="image/x-icon"
       href="<%= isDevelopment
         ? publicUrl + "favicon.ico"
-        : "https://raw.githubusercontent.com/helxplatform/appstore/%APPSTORE_ASSET_BRANCH%/appstore/core/static/images/%BRAND%/favicon.ico"
+        : "%APPSTORE_BASE_URL%/%APPSTORE_ASSET_BRANCH%/appstore/core/static/images/%BRAND%/favicon.ico"
       %>"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -7,7 +7,7 @@
       type="image/x-icon"
       href="<%= isDevelopment
         ? publicUrl + "favicon.ico"
-        : "%APPSTORE_BASE_URL%/%APPSTORE_ASSET_BRANCH%/appstore/core/static/images/%BRAND%/favicon.ico"
+        : "%APPSTORE_ASSET_BASE_URL%/%APPSTORE_ASSET_BRANCH%/appstore/core/static/images/%BRAND%/favicon.ico"
       %>"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Fixes bug where the production favicon would attempt to load from the github appstore repository rather than using `REACT_APP_APPSTORE_ASSET_BASE_URL`, causing connection issues on ASHE deployments.